### PR TITLE
Fix the admin update check and D1 database backups

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -2,15 +2,18 @@ NEXTJS_ENV=development
 # Preferred: scoped API token.
 # This is an app runtime token, not the Cloudflare deploy/build token.
 CF_TOKEN=your_api_token_with_zone_email_permissions
-CF_ACCOUNT_ID=your_account_id
+# Optional account id. Read by the database backup workflow.
+CF_AID=your_account_id
 CF_EMAIL_WORKER_NAME=mailflare
 
 # Optional: lets the admin dashboard trigger the GitHub update workflow.
 GITHUB_UPDATE_TOKEN=github_pat_with_actions_write
-GITHUB_UPDATE_REPOSITORY=owner/repo
-GITHUB_UPDATE_SOURCE_REPOSITORY=hieunc229/mailflare
-GITHUB_UPDATE_WORKFLOW=deploy-update.yml
+GITHUB_UPDATE_REPO=owner/repo
 GITHUB_UPDATE_REF=main
+
+# Optional: required for scheduled D1 database backups.
+D1_DATABASE_ID=your_d1_database_id
+D1_BACKUP_TOKEN=cloudflare_api_token_allowed_to_export_d1
 
 # Legacy Global API Key alternative. Use this only instead of CF_TOKEN.
 # CF_EMAIL=you@example.com

--- a/.github/workflows/deploy-update.yml
+++ b/.github/workflows/deploy-update.yml
@@ -20,31 +20,34 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download latest release
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Merge upstream changes
         run: |
           set -euo pipefail
-          release_json="$(curl -fsSL \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${UPDATE_SOURCE_REPOSITORY}/releases/latest")"
-          tarball_url="$(node -e 'const fs = require("fs"); const release = JSON.parse(fs.readFileSync(0, "utf8")); process.stdout.write(release.tarball_url);' <<< "${release_json}")"
-          mkdir -p /tmp/mailflare-release
-          curl -fsSL \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer ${GH_TOKEN}" \
-            "${tarball_url}" \
-            -o /tmp/mailflare-release.tar.gz
-          tar -xzf /tmp/mailflare-release.tar.gz -C /tmp/mailflare-release --strip-components=1
-          rsync -a --delete \
-            --exclude ".git" \
-            --exclude ".github" \
-            --exclude "node_modules" \
-            --exclude ".dev.vars" \
-            --exclude "wrangler.jsonc" \
-            /tmp/mailflare-release/ ./
+          git config user.name "mailflare-update"
+          git config user.email "mailflare-update@users.noreply.github.com"
+
+          upstream_url="https://github.com/${UPDATE_SOURCE_REPOSITORY}.git"
+          if git remote get-url upstream >/dev/null 2>&1; then
+            git remote set-url upstream "${upstream_url}"
+          else
+            git remote add upstream "${upstream_url}"
+          fi
+          git fetch --no-tags upstream
+
+          upstream_branch="$(git remote show upstream | sed -n 's/.*HEAD branch: //p')"
+          if [ -z "${upstream_branch}" ]; then
+            echo "::error::Could not resolve the default branch of ${UPDATE_SOURCE_REPOSITORY}."
+            exit 1
+          fi
+          echo "Merging upstream/${upstream_branch} into ${GITHUB_REF_NAME}."
+
+          # A merge keeps local modifications instead of overwriting them, and
+          # stops on conflict rather than silently discarding local work.
+          if ! git merge --no-edit "upstream/${upstream_branch}"; then
+            git merge --abort || true
+            echo "::error::Merge conflict with upstream/${upstream_branch}. Resolve it locally and push."
+            exit 1
+          fi
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -57,15 +60,11 @@ jobs:
       - name: Apply database migrations
         run: npx wrangler d1 migrations apply DB --remote
 
-      - name: Commit update
+      - name: Push update
         run: |
           set -euo pipefail
-          if [ -z "$(git status --porcelain)" ]; then
+          if [ -z "$(git log "origin/${GITHUB_REF_NAME}..HEAD" --oneline)" ]; then
             echo "Repository is already up to date."
             exit 0
           fi
-          git config user.name "mailflare-update"
-          git config user.email "mailflare-update@users.noreply.github.com"
-          git add --all
-          git commit -m "chore: update Mailflare to latest release"
           git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/src/app/api/admin/update/utils.ts
+++ b/src/app/api/admin/update/utils.ts
@@ -15,8 +15,8 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 
 const GITHUB_API_URL = "https://api.github.com";
 const GITHUB_API_VERSION = "2026-03-10";
-const UPDATE_WORKFLOW = "update.yml";
-const UPDATE_SOURCE_REPOSITORY = "hieunc229/mailflare-team";
+const UPDATE_WORKFLOW = "deploy-update.yml";
+const UPDATE_SOURCE_REPOSITORY = "hieunc229/mailflare";
 
 export async function authorizeAdminRequest(request: Request) {
   const env = getEnv();
@@ -43,11 +43,17 @@ export async function authorizeAdminRequest(request: Request) {
 
 function getDispatchConfig(env: CloudflareEnv): UpdateDispatchConfig {
   const token = env.GITHUB_UPDATE_TOKEN?.trim();
-  const repository = `hieunc229/mailflare-team`;
+  const repository = env.GITHUB_UPDATE_REPO?.trim();
   const ref = env.GITHUB_UPDATE_REF?.trim();
 
   if (!token) {
     throw new Error("GITHUB_UPDATE_TOKEN must be configured");
+  }
+
+  if (!repository) {
+    throw new Error(
+      "GITHUB_UPDATE_REPO must be configured as owner/repository",
+    );
   }
 
   return { token, repository, ref: ref || undefined };
@@ -177,25 +183,26 @@ export async function getUpdateStatus(
 export async function dispatchUpdateWorkflow() {
   const { env } = getCloudflareContext();
 
-  const ref = `main`;
-  const repository = env.GITHUB_UPDATE_REPO;
+  const config = getDispatchConfig(env);
+  const repository = config.repository;
+  const ref = await getDispatchRef(config);
 
-  const { data: wf } = await githubRequest<any>(
-    `/repos/${repository}/actions/workflows`,
-  );
-  const item = wf.workflows.find((item) => item.name === "Update Mailflare");
-
+  // Dispatch by workflow file name; GitHub accepts it in place of the numeric
+  // workflow id, so this does not depend on the workflow's display name.
   const { data, response } =
     await githubRequest<GitHubWorkflowDispatchResponse>(
-      `/repos/${repository}/actions/workflows/${item.id}/dispatches`,
+      `/repos/${repository}/actions/workflows/${UPDATE_WORKFLOW}/dispatches`,
       {
         method: "POST",
-        body: JSON.stringify({ ref: "main" }),
+        body: JSON.stringify({ ref }),
       },
     );
 
   if (!response.ok) {
-    throw new Error(data?.message ?? `GitHub returned HTTP ${response.status}`);
+    throw new Error(
+      data?.message ??
+        `GitHub returned HTTP ${response.status} dispatching ${UPDATE_WORKFLOW} in ${repository}`,
+    );
   }
 
   return {

--- a/src/lib/backups/types.d.ts
+++ b/src/lib/backups/types.d.ts
@@ -7,8 +7,14 @@ export type BackupWorkflowParams = {
 
 export type D1ExportResult = {
 	at_bookmark?: string;
+	status?: string;
+	error?: string;
 	signed_url?: string;
 	filename?: string;
+	result?: {
+		signed_url?: string;
+		filename?: string;
+	};
 };
 
 export type D1ExportResponse = {

--- a/src/lib/backups/workflow.ts
+++ b/src/lib/backups/workflow.ts
@@ -44,11 +44,14 @@ export class DatabaseBackupWorkflow extends WorkflowEntrypoint<CloudflareEnv, Ba
 			let exportFilename = "";
 			for (let attempt = 1; attempt <= EXPORT_RETRIES; attempt += 1) {
 				const result = await step.do(`Poll D1 export ${attempt}`, async () =>
-					this.callExportApi(exportUrl, { current_bookmark: bookmark }),
+					this.callExportApi(exportUrl, { output_format: "polling", current_bookmark: bookmark }),
 				);
-				if (result.result?.signed_url) {
-					signedUrl = result.result.signed_url;
-					exportFilename = result.result.filename ?? "";
+				// The polling response nests the finished export one level deeper
+				// (result.result.result); fall back to the flat shape defensively.
+				const finished = result.result?.result ?? result.result;
+				if (finished?.signed_url) {
+					signedUrl = finished.signed_url;
+					exportFilename = finished.filename ?? "";
 					break;
 				}
 				if (attempt < EXPORT_RETRIES) await step.sleep(`Wait for D1 export ${attempt}`, "15 seconds");


### PR DESCRIPTION
Deploying this app to Cloudflare surfaced five bugs that make two features unusable out of the box. Each was found and verified against a live deployment, not by reading alone.

## Admin update check

`GET /api/admin/update` fails for every installation:

- `UPDATE_SOURCE_REPOSITORY` points at `hieunc229/mailflare-team`, which is not publicly reachable (`404`), so `getTargetVersion()` always throws *"Could not read the target repository version"*.
- `getDispatchConfig()` hardcodes that same repository and ignores `GITHUB_UPDATE_REPO`, so the configured installation repository is never used.
- `dispatchUpdateWorkflow()` finds the workflow by display name `"Update Mailflare"`, but the shipped workflow is named `Dashboard Update`. `find()` returns `undefined` and the next line throws a `TypeError` on `item.id`.

Dispatching by workflow **file name** (GitHub accepts it in place of the numeric id) removes the display-name coupling for good.

## Updater overwrites local changes

The workflow rsyncs an upstream tarball over the checkout with `--delete`. Anything modified in an installation is reverted and committed on the next update — including fixes to the updater itself, which makes the feature self-defeating.

It also fetches `releases/latest`, which `404`s here because this repository has no published releases, so the first step fails before doing anything.

Replaced with a fetch and merge of the upstream default branch. That preserves local commits, matches what the README already documents ("merges them into the installation branch"), drops the release dependency, and fails loudly on conflict instead of discarding work.

## D1 database backups

Scheduled backups can never produce a file. Two independent bugs, either fatal on its own:

1. The polling request omits `output_format`, which Cloudflare requires on **every** export call, not just the first. Every poll returns `400 Invalid property: output_format => Required` until the retry limit, ending in *"D1 export did not finish before the polling limit"*.

2. The finished export is read from `result.result.signed_url`, but the API nests it one level deeper at `result.result.result.signed_url`. The export completes on the **first** poll, so the code misses it, sleeps 15s, and by the next poll Cloudflare reports *"Not currently exporting anything"* — the export is gone and unrecoverable.

Verified end to end after the fix: export through to R2, 13434 bytes, 19 tables, 21 inserts.

## Docs

`.dev.vars.example` documented names the code never reads, so following it verbatim leaves things silently unconfigured:

| Documented | Actually read |
|---|---|
| `CF_ACCOUNT_ID` | `CF_AID` |
| `GITHUB_UPDATE_REPOSITORY` | `GITHUB_UPDATE_REPO` |
| `GITHUB_UPDATE_SOURCE_REPOSITORY` | not read |
| `GITHUB_UPDATE_WORKFLOW` | not read |

Also documents `D1_DATABASE_ID` and `D1_BACKUP_TOKEN`, which the backup workflow requires. Every name in the file now resolves to a value the code reads.

---

Happy to split this into separate PRs if you'd prefer to take them piecemeal.