### PR TITLE
perf: add index on api_keys.prefix for fast API key lookups

### DIFF
--- a/drizzle/migrations/0021_add_api_keys_prefix_index.sql
+++ b/drizzle/migrations/0021_add_api_keys_prefix_index.sql
@@ -1,0 +1,2 @@
+-- Add index on api_keys.prefix for fast API key lookups
+CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(prefix);


### PR DESCRIPTION
## Summary

Performance issue found during nightly code review: `authenticateApiKey` in `src/lib/api/auth.ts` does a full table scan on the `api_keys` table by prefix.

## Problem

`authenticateApiKey` extracts the 12-char prefix from the API key and queries:
```ts
const candidates = await db.select().from(apiKeys).where(eq(apiKeys.prefix, prefix));
```

Without an index on `prefix`, this is a **full table scan O(n)**. As users create more API keys, every authenticated request becomes slower.

## Fix

Add `idx_api_keys_prefix` index on the `prefix` column:

```sql
CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(prefix);
```

This makes key lookups **O(log n)**.

## Testing

After merging, apply the migration:
```bash
npm run db:migrate:remote
```