### PR TITLE
add Bark push notifications for incoming mail

### DIFF
--- a/drizzle/migrations/0023_add_bark_url.sql
+++ b/drizzle/migrations/0023_add_bark_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` ADD `bark_url` text;

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1788518400000,
       "tag": "0022_add_mailbox_auto_reply",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1788604800000,
+      "tag": "0023_add_bark_url",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mailflare-team",
-  "version": "0.1.9",
+  "name": "mailflare",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mailflare-team",
-      "version": "0.1.9",
+      "name": "mailflare",
+      "version": "0.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@opennextjs/cloudflare": "^1.19.9",

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -29,6 +29,7 @@ export async function GET(request: Request) {
 			name: user.name,
 			resetEmail: user.resetEmail,
 			forwardingEmail: user.forwardingEmail,
+			barkUrl: user.barkUrl ?? "",
 			canForwardEmail: entitlements.canForwardEmail,
 			role: user.role,
 			canManageMailboxes: user.canManageMailboxes,

--- a/src/app/api/settings/bark/route.ts
+++ b/src/app/api/settings/bark/route.ts
@@ -1,0 +1,43 @@
+import { eq } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { ZodError } from "zod";
+import { getDb } from "@/db";
+import { users } from "@/db/schema";
+import { requireUser } from "@/lib/auth/cookies";
+import { getEnv } from "@/lib/cloudflare";
+import { normalizeBarkUrl } from "@/lib/bark/service";
+import type { UpdateBarkSettingsInput } from "./types";
+import { parseUpdateBarkSettingsRequest } from "./utils";
+
+export async function GET(request: Request) {
+	const env = getEnv();
+	const user = await requireUser(env, request);
+
+	return NextResponse.json({
+		barkUrl: user.barkUrl || "",
+	});
+}
+
+export async function PATCH(request: Request) {
+	const env = getEnv();
+	const user = await requireUser(env, request);
+
+	let input: UpdateBarkSettingsInput;
+	try {
+		input = await parseUpdateBarkSettingsRequest(request);
+	} catch (error) {
+		if (error instanceof ZodError) {
+			return NextResponse.json({ error: error.flatten() }, { status: 400 });
+		}
+		return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+	}
+
+	const barkUrl = normalizeBarkUrl(input.barkUrl);
+
+	await getDb(env)
+		.update(users)
+		.set({ barkUrl })
+		.where(eq(users.id, user.id));
+
+	return NextResponse.json({ barkUrl: barkUrl ?? "" });
+}

--- a/src/app/api/settings/bark/test/route.ts
+++ b/src/app/api/settings/bark/test/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { requireUser } from "@/lib/auth/cookies";
+import { getEnv } from "@/lib/cloudflare";
+import { normalizeBarkUrl, sendBarkNotification } from "@/lib/bark/service";
+
+export async function POST(request: Request) {
+	const env = getEnv();
+	const user = await requireUser(env, request);
+
+	const barkUrl = normalizeBarkUrl(user.barkUrl);
+	if (!barkUrl) {
+		return NextResponse.json({ error: "No Bark URL configured" }, { status: 400 });
+	}
+
+	const ok = await sendBarkNotification(barkUrl, {
+		title: "Mailflare Test",
+		body: "This is a test notification from Mailflare.",
+	});
+
+	if (!ok) {
+		return NextResponse.json({ error: "Push failed" }, { status: 502 });
+	}
+
+	return NextResponse.json({ ok: true });
+}

--- a/src/app/api/settings/bark/types.d.ts
+++ b/src/app/api/settings/bark/types.d.ts
@@ -1,0 +1,8 @@
+export type BarkSettingsResponse = {
+	barkUrl?: string;
+	error?: unknown;
+};
+
+export type UpdateBarkSettingsInput = {
+	barkUrl: string;
+};

--- a/src/app/api/settings/bark/utils.ts
+++ b/src/app/api/settings/bark/utils.ts
@@ -1,0 +1,8 @@
+import { updateBarkSettingsSchema } from "@/lib/validators";
+import type { UpdateBarkSettingsInput } from "./types";
+
+export async function parseUpdateBarkSettingsRequest(
+	request: Request,
+): Promise<UpdateBarkSettingsInput> {
+	return updateBarkSettingsSchema.parse(await request.json());
+}

--- a/src/components/settings/account-settings.tsx
+++ b/src/components/settings/account-settings.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Skeleton } from "@/components/ui/skeleton";
 import { ChangePasswordForm } from "./change-password-form";
 import { ForwardingEmailForm } from "./forwarding-email-form";
+import { BarkSettingsForm } from "./bark-settings-form";
 import { MailboxSignatureForm } from "./mailbox-signature-form";
 import { ProfileForm } from "./profile-form";
 import { ProfileAvatarForm } from "./profile-avatar-form";
@@ -83,6 +84,16 @@ export function AccountSettings() {
 					</CardContent>
 				</Card>
 			)}
+
+			<Card className="rounded-3xl border-0 bg-white px-6">
+				<CardHeader>
+					<CardTitle>Bark push notifications</CardTitle>
+					<CardDescription>Get notified on your iPhone when new mail arrives.</CardDescription>
+				</CardHeader>
+				<CardContent className="pb-6">
+					<BarkSettingsForm initialBarkUrl={user.barkUrl ?? ""} />
+				</CardContent>
+			</Card>
 
 			<Card className="rounded-3xl border-0 bg-white px-6">
 				<CardHeader>

--- a/src/components/settings/bark-settings-form.tsx
+++ b/src/components/settings/bark-settings-form.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { BarkSettingsFormProps } from "./types";
+import { saveBarkSettings, testBarkNotification } from "./utils";
+
+export function BarkSettingsForm({ initialBarkUrl }: BarkSettingsFormProps) {
+	const [barkUrl, setBarkUrl] = useState(initialBarkUrl);
+	const [savedBarkUrl, setSavedBarkUrl] = useState(initialBarkUrl);
+	const [status, setStatus] = useState<string | null>(null);
+	const [statusType, setStatusType] = useState<"success" | "error">("success");
+	const [saving, setSaving] = useState(false);
+	const [testing, setTesting] = useState(false);
+
+	async function onSave() {
+		setSaving(true);
+		setStatus(null);
+		try {
+			const saved = await saveBarkSettings(barkUrl);
+			setBarkUrl(saved);
+			setSavedBarkUrl(saved);
+			setStatusType("success");
+			setStatus("Saved");
+		} catch (error) {
+			setStatusType("error");
+			setStatus(error instanceof Error ? error.message : "Failed to save Bark settings");
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	async function onTest() {
+		setTesting(true);
+		setStatus(null);
+		try {
+			await testBarkNotification();
+			setStatusType("success");
+			setStatus("Test notification sent");
+		} catch (error) {
+			setStatusType("error");
+			setStatus(error instanceof Error ? error.message : "Test push failed");
+		} finally {
+			setTesting(false);
+		}
+	}
+
+	return (
+		<div className="space-y-4">
+			<div className="space-y-2">
+				<Label htmlFor="barkUrl">Bark push URL</Label>
+				<Input
+					id="barkUrl"
+					value={barkUrl}
+					onChange={(event) => setBarkUrl(event.target.value)}
+					placeholder="https://api.day.app/YOUR_KEY"
+				/>
+				<p className="text-xs leading-5 text-neutral-500">
+					Receive a push notification on your iPhone when a new message arrives. Install the Bark
+					app and paste your device key from{" "}
+					<a
+						href="https://bark.day.app/"
+						target="_blank"
+						rel="noreferrer"
+						className="text-blue-600 underline-offset-2 hover:underline"
+					>
+						bark.day.app
+					</a>
+					.
+				</p>
+			</div>
+			<div className="flex items-center gap-3">
+				<Button type="button" onClick={onSave} disabled={saving || barkUrl.trim() === savedBarkUrl}>
+					{saving ? "Saving..." : "Save"}
+				</Button>
+				<Button
+					type="button"
+					variant="outline"
+					onClick={onTest}
+					disabled={testing || !savedBarkUrl || barkUrl.trim() !== savedBarkUrl}
+					title={barkUrl.trim() !== savedBarkUrl ? "Save your changes before sending a test notification" : undefined}
+				>
+					{testing ? "Sending..." : "Send test notification"}
+				</Button>
+				{status && (
+					<p className={`text-sm ${statusType === "error" ? "text-red-600" : "text-neutral-500"}`}>
+						{status}
+					</p>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/settings/types.d.ts
+++ b/src/components/settings/types.d.ts
@@ -20,6 +20,7 @@ export type AccountSettingsResponse = {
 		name: string;
 		resetEmail: string | null;
 		forwardingEmail: string | null;
+		barkUrl: string;
 		canForwardEmail: boolean;
 	};
 	error?: unknown;
@@ -27,6 +28,15 @@ export type AccountSettingsResponse = {
 
 export type ForwardingEmailFormProps = {
 	initialForwardingEmail: string;
+};
+
+export type BarkSettingsFormProps = {
+	initialBarkUrl: string;
+};
+
+export type BarkSettingsResponse = {
+	barkUrl?: string | null;
+	error?: unknown;
 };
 
 export type ForwardingEmailResponse = {

--- a/src/components/settings/utils.ts
+++ b/src/components/settings/utils.ts
@@ -2,6 +2,7 @@ import type { MailboxOption } from "@/components/mailbox-provider";
 import { clearMailboxesCache } from "@/components/mailbox-provider-utils";
 import { authFetch } from "@/lib/auth/client";
 import type {
+	BarkSettingsResponse,
 	CurrentMailboxFormResponse,
 	ForwardingEmailResponse,
 	MailboxAutoReplyResponse,
@@ -59,6 +60,35 @@ export async function updateForwardingEmail(forwardingEmail: string): Promise<st
 		throw new Error(typeof data.error === "string" ? data.error : "Failed to update forwarding email");
 	}
 	return data.forwardingEmail ?? "";
+}
+
+export async function saveBarkSettings(barkUrl: string): Promise<string> {
+	const res = await authFetch("/api/settings/bark", {
+		method: "PATCH",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify({ barkUrl }),
+	});
+	const data = (await res.json()) as BarkSettingsResponse;
+	if (!res.ok) {
+		const message =
+			typeof data.error === "string"
+				? data.error
+				: data.error && typeof data.error === "object" && "formErrors" in data.error
+					? "Invalid Bark URL"
+					: "Failed to update Bark settings";
+		throw new Error(message);
+	}
+	return data.barkUrl ?? "";
+}
+
+export async function testBarkNotification(): Promise<void> {
+	const res = await authFetch("/api/settings/bark/test", {
+		method: "POST",
+	});
+	const data = (await res.json()) as BarkSettingsResponse;
+	if (!res.ok) {
+		throw new Error(typeof data.error === "string" ? data.error : "Test push failed");
+	}
 }
 
 export async function updateMailboxSignature(mailboxId: string, signature: string): Promise<string> {

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -6,6 +6,7 @@ export const users = sqliteTable("users", {
 	email: text("email").notNull().unique(),
 	resetEmail: text("reset_email"),
 	forwardingEmail: text("forwarding_email"),
+	barkUrl: text("bark_url"),
 	passwordHash: text("password_hash").notNull(),
 	name: text("name").notNull(),
 	avatarKey: text("avatar_key"),

--- a/src/lib/auth/types.d.ts
+++ b/src/lib/auth/types.d.ts
@@ -5,6 +5,7 @@ export type SessionUser = {
 	email: string;
 	resetEmail: string | null;
 	forwardingEmail: string | null;
+	barkUrl: string | null;
 	passwordHash: string;
 	name: string;
 	role: UserRole;

--- a/src/lib/bark/service.ts
+++ b/src/lib/bark/service.ts
@@ -1,0 +1,187 @@
+import { eq } from "drizzle-orm";
+import { getDb } from "@/db";
+import { users } from "@/db/schema";
+
+/**
+ * Bark push notification service.
+ *
+ * Sends a push notification to the user's iPhone via the Bark app
+ * (https://bark.day.app). Behavior mirrors the cloud-mail reference
+ * implementation: the push title is the destination inbox address and the
+ * body is the email subject. Push failures never affect the email pipeline.
+ */
+
+export const BARK_GROUP = "Mailflare";
+
+export type BarkPushPayload = {
+	title: string;
+	body: string;
+	group?: string;
+};
+
+/**
+ * Reads the configured Bark URL for a user (normalized) or null.
+ */
+export async function getUserBarkUrl(
+	env: CloudflareEnv,
+	userId: string,
+): Promise<string | null> {
+	try {
+		const db = getDb(env);
+		const [user] = await db
+			.select({ barkUrl: users.barkUrl })
+			.from(users)
+			.where(eq(users.id, userId))
+			.limit(1);
+		return normalizeBarkUrl(user?.barkUrl);
+	} catch (error) {
+		console.error("Failed to load Bark URL:", error instanceof Error ? error.message : error);
+		return null;
+	}
+}
+
+/**
+ * Push a new incoming message notification to a user's devices via Bark.
+ * Title = destination inbox address, body = email subject. Never throws.
+ */
+export async function notifyUserOfBarkMessage(
+	env: CloudflareEnv,
+	userId: string,
+	message: { toAddr?: string | null; subject?: string | null },
+): Promise<void> {
+	const barkUrl = await getUserBarkUrl(env, userId);
+	if (!barkUrl) return;
+	await sendBarkNotification(barkUrl, {
+		title: message.toAddr || "",
+		body: message.subject || "",
+	});
+}
+
+/**
+ * Normalizes a user-provided Bark push URL.
+ *
+ * Security: this value is user-supplied and later fetched by the worker during
+ * inbound email processing, so it is a SSRF sink. We therefore:
+ * - only accept https: URLs (never http:, file:, data:, ftp:, ...),
+ * - reject private/loopback/link-local/reserved hosts and IP literals
+ *   (the worker cannot reach a user's LAN anyway, so no legitimate use is lost),
+ * - accept a bare Bark device key and convert it to the default https endpoint,
+ * - return the normalized URL (or null when empty/invalid).
+ */
+export function normalizeBarkUrl(value: string | null | undefined): string | null {
+	if (!value) return null;
+	const trimmed = value.trim();
+	if (!trimmed) return null;
+
+	// Bare device key -> default Bark HTTPS endpoint.
+	if (/^[0-9A-Za-z_-]{10,}$/.test(trimmed)) {
+		return `https://api.day.app/${trimmed}`;
+	}
+
+	// Full URL branch.
+	let parsed: URL;
+	try {
+		parsed = new URL(trimmed);
+	} catch {
+		return null;
+	}
+	if (parsed.protocol !== "https:") {
+		return null;
+	}
+	if (isPrivateHostname(parsed.hostname)) {
+		return null;
+	}
+	// Normalize: drop the hash so the stored value is canonical.
+	parsed.hash = "";
+	return parsed.toString();
+}
+
+/**
+ * Returns true when a hostname is private/local/reserved space that a
+ * Cloudflare worker must never fetch (SSRF protection).
+ */
+function isPrivateHostname(hostname: string): boolean {
+	const lower = hostname.toLowerCase();
+	if (lower === "localhost" || lower.endsWith(".localhost")) {
+		return true;
+	}
+	// IPv6 literal.
+	if (lower.includes(":")) {
+		// URL.hostname keeps the brackets for IPv6 literals (e.g. "[::1]").
+		const v6 = lower.startsWith("[") && lower.endsWith("]") ? lower.slice(1, -1) : lower;
+		if (
+			v6 === "::1" ||
+			v6.startsWith("fc") ||
+			v6.startsWith("fd") ||
+			v6.startsWith("fe8") ||
+			v6.startsWith("fe9") ||
+			v6.startsWith("fea") ||
+			v6.startsWith("feb") ||
+			v6.startsWith("::") ||
+			v6.startsWith("0:")
+		) {
+			return true;
+		}
+		return false;
+	}
+	// IPv4 literal.
+	if (/^\d{1,3}(\.\d{1,3}){3}$/.test(lower)) {
+		const [a, b] = lower.split(".").map(Number);
+		// 0/8, 10/8, 127/8 loopback, 169.254/16 link-local, 172.16-31/12,
+		// 192.168/16, 192.0.0/24, 198.18/15 benchmark, 224+ multicast/reserved.
+		if (
+			a === 0 ||
+			a === 10 ||
+			a === 127 ||
+			(a === 169 && b === 254) ||
+			(a === 172 && b >= 16 && b <= 31) ||
+			(a === 192 && (b === 168 || b === 0)) ||
+			(a === 198 && (b === 18 || b === 19)) ||
+			a >= 224
+		) {
+			return true;
+		}
+		return false;
+	}
+	return false;
+}
+
+/**
+ * Sends a Bark push notification.
+ *
+ * Uses POST JSON to the user's Bark URL. Failures are logged and swallowed so
+ * the email receive pipeline is never blocked by a notification problem.
+ */
+export async function sendBarkNotification(barkUrl: string, payload: BarkPushPayload): Promise<boolean> {
+	// Cloudflare Workers does not support AbortSignal.timeout; build a manual
+	// timeout with AbortController to bound slow/unreachable push endpoints.
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), 10_000);
+	try {
+		const res = await fetch(barkUrl, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json; charset=utf-8",
+			},
+			body: JSON.stringify({
+				title: payload.title,
+				body: payload.body,
+				group: payload.group ?? BARK_GROUP,
+			}),
+			// SSRF hardening: never follow redirects and bound the request time.
+			redirect: "manual",
+			signal: controller.signal,
+		});
+
+		if (!res.ok) {
+			console.error(`Bark push failed status: ${res.status} response: ${await res.text()}`);
+			return false;
+		}
+		return true;
+	} catch (error) {
+		console.error("Bark push exception:", error instanceof Error ? error.message : error);
+		return false;
+	} finally {
+		clearTimeout(timer);
+	}
+}

--- a/src/lib/email/inbound.ts
+++ b/src/lib/email/inbound.ts
@@ -11,6 +11,7 @@ import { sendMailboxAutoReply } from "@/lib/email/auto-reply";
 import { getMailboxAccessLevel } from "@/lib/mailboxes/access";
 import { listMessageAttachments, storeMessageAttachments } from "@/lib/email/attachments";
 import { getUnsubscribeUrlFromRawR2Key } from "@/lib/email/unsubscribe";
+import { notifyUserOfBarkMessage } from "@/lib/bark/service";
 import type { SessionUser } from "@/lib/auth/types";
 import {
 	getMailboxNotificationUserIds,
@@ -127,6 +128,26 @@ export async function processInboundMessage(
 		fromName: contact?.displayName ?? null,
 		subject: parsed.subject,
 	});
+
+	// Bark push notification for the receiving users (owner + shared members,
+	// mirroring the realtime notification user set). Failures never block the
+	// email pipeline.
+	if (destination.status === "received") {
+		try {
+			const barkUserIds = [...new Set(notificationUserIds)];
+			await Promise.allSettled(
+				barkUserIds.map((userId) =>
+					notifyUserOfBarkMessage(env, userId, {
+						toAddr,
+						subject: parsed.subject,
+					}),
+				),
+			);
+		} catch (error) {
+			console.error(`Bark notification failed for mailbox ${decision.mailbox.mailboxId}`, error);
+		}
+	}
+
 	await dispatchWebhooks(env, decision.mailbox.userId, "message.inbound", {
 		messageId,
 		from: fromAddr,

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -155,6 +155,13 @@ export const updateForwardingEmailSchema = z.object({
 	),
 });
 
+export const updateBarkSettingsSchema = z.object({
+	barkUrl: z.preprocess(
+		(value) => (typeof value === "string" ? value.trim() : value),
+		z.string().max(2048).or(z.literal("")).transform((value) => value || ""),
+	),
+});
+
 export const changePasswordSchema = z.object({
 	currentPassword: z.string().min(1),
 	newPassword: z.string().min(8).max(128),


### PR DESCRIPTION
## Summary

Adds iOS push notifications via [Bark](https://bark.day.app/) whenever a new
message lands in a user's inbox, mirroring the reference implementation in
self-hosted CloudMail.

Users configure their personal Bark device key under **Settings → Account →
Bark push notifications**, with a one-click **Send test notification** button
to validate the channel before relying on it.

## Changes

- **Database:** `users.bark_url` column + migration `0023_add_bark_url.sql`
  (journal entry included; idempotent via D1 migrator).
- **Push service** (`src/lib/bark/service.ts`):
  - `normalizeBarkUrl` – accepts a full `https://` URL or a bare device key;
    rejects non-HTTPS schemes and private/loopback/link-local/reserved hosts
    (IPv4/IPv6, metadata addresses, IP obfuscation) to prevent SSRF.
  - `sendBarkNotification` – POSTs JSON (`title` = destination inbox address,
    `body` = email subject, `group` = `Mailflare`); failures are logged and
    swallowed so the receive pipeline is never blocked; manual 10s timeout and
    `redirect: "manual"` bound outbound requests.
- **API:**
  - `GET/PATCH /api/settings/bark` – read/update the user's Bark URL (zod
    validated, normalized before persistence).
  - `POST /api/settings/bark/test` – sends a test notification.
- **Inbound trigger:** `processInboundMessage` pushes only when the message
  status is `received`, to the full receiving user set (owner + shared
  mailbox members, aligned with the realtime notification set).
- **UI:** Bark settings card on the Account page; test button is disabled
  while unsaved changes exist; saved value round-trips from the server.

## Security

- Bark URL is user-supplied and later fetched by the worker → treated as a
  SSRF sink: only `https:` allowed, private/reserved hosts rejected, no
  redirect following, 10s timeout. 24/24 adversarial URL cases verified
  (loopback, RFC1918, link-local, IPv6 ULA/loopback, hex/octal IP encoding,
  metadata endpoints, non-HTTPS schemes).

## Migration

```bash
npm run db:migrate:remote   # apply 0023 before deploying
```