### PR TITLE
fix(backups): back up the tables added since the format shipped

### DIFF
--- a/src/lib/backups/export.ts
+++ b/src/lib/backups/export.ts
@@ -1,14 +1,48 @@
 import type { DatabaseBackupDocument, DatabaseBackupTable, DatabaseRecord } from "./types";
 import { mergeLegacyMessageBodies } from "./utils";
 
-const BACKUP_TABLES: DatabaseBackupTable[] = ["users", "domains", "mailboxes", "mailbox_access", "contacts", "folders", "api_keys", "messages", "message_attachments", "outbound_jobs", "routing_rules", "webhooks", "webhook_deliveries", "sessions", "audit_logs", "backup_settings", "backups", "app_settings", "license_settings"];
+const BACKUP_TABLES: DatabaseBackupTable[] = ["users", "domains", "mailboxes", "mailbox_access", "contacts", "folders", "api_keys", "messages", "message_attachments", "outbound_jobs", "routing_rules", "webhooks", "webhook_deliveries", "sessions", "audit_logs", "backup_settings", "backups", "app_settings", "license_settings", "email_templates", "calendar_events", "auto_reply_deliveries"];
+/**
+ * Tables every backup document must contain. Tables added to BACKUP_TABLES
+ * after the format shipped are absent from older documents, so they stay
+ * optional here and are filled in as empty on restore.
+ */
+const REQUIRED_BACKUP_TABLES: DatabaseBackupTable[] = ["users", "domains", "mailboxes", "mailbox_access", "contacts", "folders", "api_keys", "messages", "message_attachments", "outbound_jobs", "routing_rules", "webhooks", "webhook_deliveries", "sessions", "audit_logs", "backup_settings", "backups", "app_settings", "license_settings"];
 const INSERT_BATCH_SIZE = 50;
 
 export function getD1ExportConfigurationStatus(_env?: CloudflareEnv) {
 	return { configured: true, missing: [] };
 }
 
+/**
+ * Tables D1 manages itself, which are intentionally absent from BACKUP_TABLES.
+ */
+const INTERNAL_TABLE_PATTERNS = ["sqlite_%", "_cf%"];
+const INTERNAL_TABLES = ["d1_migrations"];
+
+/**
+ * Fails the backup when the database contains a table BACKUP_TABLES does not
+ * list. Without this, a migration that adds a table silently produces backups
+ * that omit it, and the omission only surfaces during a restore.
+ */
+export async function assertBackupTablesCoverDatabase(db: D1Database): Promise<void> {
+	const conditions = [
+		...INTERNAL_TABLE_PATTERNS.map((pattern) => `name NOT LIKE '${pattern}'`),
+		...INTERNAL_TABLES.map((name) => `name <> '${name}'`),
+	].join(" AND ");
+	const result = await db
+		.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND ${conditions}`)
+		.all<{ name: string }>();
+	const covered = new Set<string>(BACKUP_TABLES);
+	const unlisted = result.results.map((row) => row.name).filter((name) => !covered.has(name));
+	if (unlisted.length === 0) return;
+	throw new Error(
+		`Backup aborted: ${unlisted.join(", ")} not listed in BACKUP_TABLES, so this backup would omit them. Add them to BACKUP_TABLES in src/lib/backups/export.ts.`,
+	);
+}
+
 export async function exportDatabaseRecords(db: D1Database): Promise<Uint8Array> {
+	await assertBackupTablesCoverDatabase(db);
 	const tables = {} as Record<DatabaseBackupTable, DatabaseRecord[]>;
 	for (const table of BACKUP_TABLES) {
 		const result = await db.prepare(`SELECT * FROM ${table}`).all<DatabaseRecord>();
@@ -21,6 +55,7 @@ export async function exportDatabaseRecords(db: D1Database): Promise<Uint8Array>
 export async function restoreDatabaseRecords(db: D1Database, content: ArrayBuffer): Promise<void> {
 	const document = parseDatabaseBackup(content);
 	mergeLegacyMessageBodies(document);
+	fillMissingBackupTables(document);
 	validateDatabaseBackup(document);
 	for (const table of [...BACKUP_TABLES].reverse()) await db.prepare(`DELETE FROM ${table}`).run();
 	for (const table of BACKUP_TABLES) {
@@ -42,7 +77,12 @@ function parseDatabaseBackup(content: ArrayBuffer): DatabaseBackupDocument {
 function isDatabaseBackupDocument(value: unknown): value is DatabaseBackupDocument {
 	if (!value || typeof value !== "object") return false;
 	const document = value as Partial<DatabaseBackupDocument>;
-	return document.format === "mailflare-database-backup" && document.version === 1 && !!document.tables && BACKUP_TABLES.every((table) => Array.isArray(document.tables?.[table]));
+	if (document.format !== "mailflare-database-backup" || document.version !== 1 || !document.tables) return false;
+	if (!REQUIRED_BACKUP_TABLES.every((table) => Array.isArray(document.tables?.[table]))) return false;
+	return BACKUP_TABLES.every((table) => {
+		const rows = document.tables?.[table];
+		return rows === undefined || Array.isArray(rows);
+	});
 }
 
 function createInsertStatement(db: D1Database, table: DatabaseBackupTable, row: DatabaseRecord) {
@@ -51,6 +91,13 @@ function createInsertStatement(db: D1Database, table: DatabaseBackupTable, row: 
 	const placeholders = columns.map(() => "?").join(", ");
 	const identifiers = columns.map((column) => `\`${column.replaceAll("`", "``")}\``).join(", ");
 	return db.prepare(`INSERT INTO ${table} (${identifiers}) VALUES (${placeholders})`).bind(...columns.map((column) => row[column]));
+}
+
+/** Backups written before a table joined BACKUP_TABLES simply omit it. */
+function fillMissingBackupTables(document: DatabaseBackupDocument): void {
+	for (const table of BACKUP_TABLES) {
+		if (!document.tables[table]) document.tables[table] = [];
+	}
 }
 
 function validateDatabaseBackup(document: DatabaseBackupDocument): void {

--- a/src/lib/backups/types.d.ts
+++ b/src/lib/backups/types.d.ts
@@ -12,6 +12,6 @@ export type BackupWorkflowBinding = {
 	}): Promise<unknown>;
 };
 
-export type DatabaseBackupTable = "users" | "domains" | "mailboxes" | "mailbox_access" | "contacts" | "folders" | "api_keys" | "messages" | "message_attachments" | "outbound_jobs" | "routing_rules" | "webhooks" | "webhook_deliveries" | "sessions" | "audit_logs" | "backup_settings" | "backups" | "app_settings" | "license_settings";
+export type DatabaseBackupTable = "users" | "domains" | "mailboxes" | "mailbox_access" | "contacts" | "folders" | "api_keys" | "messages" | "message_attachments" | "outbound_jobs" | "routing_rules" | "webhooks" | "webhook_deliveries" | "sessions" | "audit_logs" | "backup_settings" | "backups" | "app_settings" | "license_settings" | "email_templates" | "calendar_events" | "auto_reply_deliveries";
 export type DatabaseRecord = Record<string, string | number | null>;
 export type DatabaseBackupDocument = { format: "mailflare-database-backup"; version: 1; createdAt: string; tables: Record<DatabaseBackupTable, DatabaseRecord[]>; };


### PR DESCRIPTION
## Problem

`BACKUP_TABLES` in `src/lib/backups/export.ts` is a hardcoded list, and the migrations that added `email_templates` and `calendar_events` (`0020`) and `auto_reply_deliveries` (`0022`) never updated it.

Those three tables are absent from **every** backup. Because `restoreDatabaseRecords` only touches listed tables, restoring into an empty database silently loses calendar events and email templates, and nothing reports a problem — the omission only surfaces during a restore, when the data is already gone.

I found this on a live instance: 22 tables in the database, 19 in the list.

## Changes

**Add the three tables.** Appended at the end of the list, which keeps restore FK-safe — the reverse-order delete still removes children before parents, and the forward-order insert still writes them after `users` and `mailboxes`, which they reference.

**Add `assertBackupTablesCoverDatabase`.** It compares `sqlite_master` against `BACKUP_TABLES` and aborts the backup naming any unlisted table, so a future migration cannot silently produce incomplete backups. A backup that fails loudly is recoverable; one that quietly omits a table is not.

**Keep older backups restorable.** This is the subtle part. Extending the list would by itself have broken restores of every existing backup: `isDatabaseBackupDocument` required *every* `BACKUP_TABLES` entry to be present, and documents written before this change have only the original nineteen — they would be rejected as "not a valid Mailflare backup", and `validateDatabaseBackup`/`restoreDatabaseRecords` would then throw on the missing keys. So the list is split: `REQUIRED_BACKUP_TABLES` (the original nineteen) must be present, tables added later are optional on read and filled with an empty array before validation. Documents missing an original table are still rejected.

## Testing

Verified against a real database with all migrations applied, and against a real 19-table backup document:

| Case | Result |
|---|---|
| Guard vs. fully migrated schema | passes, nothing unlisted |
| Guard with a table removed from the list | correctly aborts, naming it |
| Existing 19-table backup | accepted, filled to 22, all messages preserved |
| Backup missing a required table (`users`) | still rejected |
| New 22-table backup | accepted |

`npx tsc --noEmit` reports the same 14 pre-existing errors before and after, and `opennextjs-cloudflare build` succeeds. A backup run on a deployed instance after this change completes with no error and covers all 22 tables.

## Note

I kept the table list explicit rather than discovering tables from `sqlite_master`, because dynamic discovery would change the ordering guarantees the restore path depends on, and restore is destructive enough that I did not want to rework it blind. If you would rather it were dynamic, happy to take that on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)