### PR TITLE
feat(mailboxes): add arbitrary email aliases

### DIFF
--- a/drizzle/migrations/0023_add_mailbox_aliases.sql
+++ b/drizzle/migrations/0023_add_mailbox_aliases.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `mailbox_aliases` (
+	`id` text PRIMARY KEY NOT NULL,
+	`mailbox_id` text NOT NULL REFERENCES `mailboxes`(`id`) ON DELETE cascade,
+	`domain_id` text NOT NULL REFERENCES `domains`(`id`) ON DELETE cascade,
+	`local_part` text NOT NULL,
+	`created_at` integer NOT NULL
+);
+CREATE UNIQUE INDEX `mailbox_aliases_address_idx` ON `mailbox_aliases` (`domain_id`, `local_part`);
+CREATE INDEX `mailbox_aliases_mailbox_idx` ON `mailbox_aliases` (`mailbox_id`);

--- a/drizzle/migrations/meta/_journal.json
+++ b/drizzle/migrations/meta/_journal.json
@@ -162,6 +162,13 @@
       "when": 1788518400000,
       "tag": "0022_add_mailbox_auto_reply",
       "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "6",
+      "when": 1788604800000,
+      "tag": "0023_add_mailbox_aliases",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "mailflare-team",
-  "version": "0.1.9",
+  "name": "mailflare",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "mailflare-team",
-      "version": "0.1.9",
+      "name": "mailflare",
+      "version": "0.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@opennextjs/cloudflare": "^1.19.9",

--- a/src/app/(admin)/mailboxes/[id]/page.tsx
+++ b/src/app/(admin)/mailboxes/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Save, Trash2, UserPlus } from "lucide-react";
+import { AtSign, Save, Trash2, UserPlus } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -19,8 +19,11 @@ import { Label } from "@/components/ui/label";
 import { Select } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  createMailboxAlias,
   deleteMailbox,
+  deleteMailboxAlias,
   fetchMailbox,
+  fetchMailboxAliases,
   fetchSharedInboxAccess,
   getMailboxAddress,
   grantSharedInboxAccess,
@@ -36,6 +39,8 @@ export default function MailboxSettingsPage() {
   const [displayName, setDisplayName] = useState("");
   const [useAllDomains, setUseAllDomains] = useState(true);
   const [selectedUserId, setSelectedUserId] = useState("");
+  const [aliasLocalPart, setAliasLocalPart] = useState("");
+  const [aliasDomainId, setAliasDomainId] = useState("");
 
   const mailbox = useQuery({
     queryKey: ["mailbox", mailboxId],
@@ -47,6 +52,7 @@ export default function MailboxSettingsPage() {
     if (mailbox.data) {
       setDisplayName(mailbox.data.displayName ?? "");
       setUseAllDomains(mailbox.data.useAllDomains);
+      setAliasDomainId((current) => current || mailbox.data.domainId);
     }
   }, [mailbox.data]);
 
@@ -65,6 +71,27 @@ export default function MailboxSettingsPage() {
       await qc.invalidateQueries({ queryKey: ["mailboxes"] });
       router.push("/mailboxes");
     },
+  });
+
+  const aliases = useQuery({
+    queryKey: ["mailbox", mailboxId, "aliases"],
+    queryFn: () => fetchMailboxAliases(mailboxId),
+    enabled: !!mailboxId,
+  });
+  const addAlias = useMutation({
+    mutationFn: () =>
+      createMailboxAlias(mailboxId, {
+        domainId: aliasDomainId,
+        localPart: aliasLocalPart.trim(),
+      }),
+    onSuccess: async () => {
+      setAliasLocalPart("");
+      await qc.invalidateQueries({ queryKey: ["mailbox", mailboxId, "aliases"] });
+    },
+  });
+  const removeAlias = useMutation({
+    mutationFn: (aliasId: string) => deleteMailboxAlias(mailboxId, aliasId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["mailbox", mailboxId, "aliases"] }),
   });
 
   const sharedAccess = useQuery({
@@ -174,6 +201,95 @@ export default function MailboxSettingsPage() {
             <Save className="h-4 w-4" />
             {updateName.isPending ? "Saving..." : "Save changes"}
           </Button>
+        </CardContent>
+      </Card>
+
+      <Card className="rounded-3xl border-0 bg-white p-6">
+        <CardHeader className="py-0">
+          <CardTitle>Aliases</CardTitle>
+          <CardDescription>
+            Extra addresses that deliver to this mailbox. You can also send mail
+            from any alias.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4 pt-5">
+          {aliases.isLoading && <Skeleton className="h-12 w-full rounded-2xl" />}
+          {(aliases.data?.aliases ?? []).map((alias) => (
+            <div
+              key={alias.id}
+              className="flex items-center justify-between gap-3 rounded-2xl bg-neutral-50 px-4 py-3"
+            >
+              <div className="flex min-w-0 items-center gap-2">
+                <AtSign className="h-4 w-4 shrink-0 text-neutral-400" />
+                <p className="truncate no-font-mono text-sm font-medium text-neutral-900">
+                  {alias.localPart}@{alias.hostname}
+                </p>
+              </div>
+              <Button
+                type="button"
+                size="icon"
+                variant="ghost"
+                aria-label={`Remove ${alias.localPart}@${alias.hostname}`}
+                disabled={removeAlias.isPending}
+                onClick={() => removeAlias.mutate(alias.id)}
+              >
+                <Trash2 className="h-4 w-4 text-red-600" />
+              </Button>
+            </div>
+          ))}
+          {aliases.data && aliases.data.aliases.length === 0 && (
+            <p className="rounded-2xl bg-neutral-50 px-4 py-3 text-sm text-neutral-500">
+              No aliases yet.
+            </p>
+          )}
+          {aliases.isError && (
+            <p className="text-sm text-red-600">
+              {aliases.error instanceof Error
+                ? aliases.error.message
+                : "Failed to load aliases"}
+            </p>
+          )}
+          <div className="flex gap-2">
+            <Input
+              value={aliasLocalPart}
+              onChange={(event) => setAliasLocalPart(event.target.value)}
+              placeholder="alias"
+              className="min-w-0 flex-1"
+              disabled={addAlias.isPending}
+            />
+            <Select
+              value={aliasDomainId}
+              onChange={(event) => setAliasDomainId(event.target.value)}
+              className="h-10 min-w-0 flex-1 text-sm"
+              disabled={addAlias.isPending}
+            >
+              {(aliases.data?.availableDomains ?? []).map((domain) => (
+                <option key={domain.id} value={domain.id}>
+                  @{domain.hostname}
+                </option>
+              ))}
+            </Select>
+            <Button
+              type="button"
+              disabled={!aliasLocalPart.trim() || !aliasDomainId || addAlias.isPending}
+              onClick={() => addAlias.mutate()}
+            >
+              <AtSign className="h-4 w-4" />
+              {addAlias.isPending ? "Adding..." : "Add alias"}
+            </Button>
+          </div>
+          {addAlias.isError && (
+            <p className="text-sm text-red-600">
+              {addAlias.error instanceof Error ? addAlias.error.message : "Failed to add alias"}
+            </p>
+          )}
+          {removeAlias.isError && (
+            <p className="text-sm text-red-600">
+              {removeAlias.error instanceof Error
+                ? removeAlias.error.message
+                : "Failed to remove alias"}
+            </p>
+          )}
         </CardContent>
       </Card>
 

--- a/src/app/(admin)/mailboxes/[id]/types.d.ts
+++ b/src/app/(admin)/mailboxes/[id]/types.d.ts
@@ -29,6 +29,25 @@ export type MailboxAvatarUploadResponse = {
 	error?: string;
 };
 
+export type MailboxAlias = {
+	id: string;
+	domainId: string;
+	localPart: string;
+	hostname: string;
+	createdAt: string;
+};
+
+export type MailboxAliasDomain = {
+	id: string;
+	hostname: string;
+};
+
+export type MailboxAliasesResponse = {
+	aliases: MailboxAlias[];
+	availableDomains: MailboxAliasDomain[];
+	error?: string;
+};
+
 export type SharedInboxMember = {
 	id: string;
 	userId: string;

--- a/src/app/(admin)/mailboxes/[id]/utils.ts
+++ b/src/app/(admin)/mailboxes/[id]/utils.ts
@@ -1,6 +1,6 @@
 import { authFetch } from "@/lib/auth/client";
 import { clearMailboxesCache } from "@/components/mailbox-provider-utils";
-import type { MailboxDetail, MailboxDetailResponse, SharedInboxAccessResponse } from "./types";
+import type { MailboxAliasesResponse, MailboxDetail, MailboxDetailResponse, SharedInboxAccessResponse } from "./types";
 
 export function getMailboxAddress(mailbox: Pick<MailboxDetail, "localPart" | "hostname">): string {
 	return `${mailbox.localPart}@${mailbox.hostname}`;
@@ -59,6 +59,38 @@ export async function revokeSharedInboxAccess(id: string, userId: string): Promi
 	});
 	const json = (await res.json()) as { error?: string };
 	if (!res.ok) throw new Error(json.error ?? "Failed to remove account");
+}
+
+export async function fetchMailboxAliases(id: string): Promise<MailboxAliasesResponse> {
+	const res = await authFetch(`/api/mailboxes/${id}/aliases`);
+	const json = (await res.json()) as MailboxAliasesResponse;
+	if (!res.ok) throw new Error(json.error ?? "Failed to load aliases");
+	return json;
+}
+
+export async function createMailboxAlias(
+	id: string,
+	input: { domainId: string; localPart: string },
+): Promise<void> {
+	const res = await authFetch(`/api/mailboxes/${id}/aliases`, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(input),
+	});
+	const json = (await res.json()) as { error?: string };
+	if (!res.ok) throw new Error(json.error ?? "Failed to add alias");
+
+	clearMailboxesCache();
+}
+
+export async function deleteMailboxAlias(id: string, aliasId: string): Promise<void> {
+	const res = await authFetch(`/api/mailboxes/${id}/aliases?aliasId=${encodeURIComponent(aliasId)}`, {
+		method: "DELETE",
+	});
+	const json = (await res.json()) as { error?: string };
+	if (!res.ok) throw new Error(json.error ?? "Failed to remove alias");
+
+	clearMailboxesCache();
 }
 
 export async function deleteMailbox(id: string): Promise<void> {

--- a/src/app/api/mailboxes/[id]/aliases/route.ts
+++ b/src/app/api/mailboxes/[id]/aliases/route.ts
@@ -1,0 +1,194 @@
+import { and, eq, ne } from "drizzle-orm";
+import { NextResponse } from "next/server";
+import { getDb } from "@/db";
+import { domains, mailboxAliases, mailboxes } from "@/db/schema";
+import { requireUser } from "@/lib/auth/cookies";
+import { getEnv } from "@/lib/cloudflare";
+import { deleteEmailRoutingRuleForAddress, ensureEmailRoutingRuleToWorker } from "@/lib/cloudflare-api";
+import { newId } from "@/lib/ids";
+import { getMailboxAccessLevel } from "@/lib/mailboxes/access";
+import { createMailboxAliasSchema } from "@/lib/validators";
+import type { MailboxRouteParams } from "../types";
+
+async function getManagedMailbox(
+	db: ReturnType<typeof getDb>,
+	user: Awaited<ReturnType<typeof requireUser>>,
+	mailboxId: string,
+) {
+	const access = await getMailboxAccessLevel(db, user, mailboxId);
+	if (!access?.canManage) return null;
+	const [mailbox] = await db
+		.select({ id: mailboxes.id, domainId: mailboxes.domainId, localPart: mailboxes.localPart })
+		.from(mailboxes)
+		.where(eq(mailboxes.id, mailboxId))
+		.limit(1);
+	return mailbox ?? null;
+}
+
+async function getDomainOwnerId(db: ReturnType<typeof getDb>, domainId: string) {
+	const [domain] = await db
+		.select({ userId: domains.userId })
+		.from(domains)
+		.where(eq(domains.id, domainId))
+		.limit(1);
+	return domain?.userId ?? null;
+}
+
+function listMailboxAliases(db: ReturnType<typeof getDb>, mailboxId: string) {
+	return db
+		.select({
+			id: mailboxAliases.id,
+			domainId: mailboxAliases.domainId,
+			localPart: mailboxAliases.localPart,
+			hostname: domains.hostname,
+			createdAt: mailboxAliases.createdAt,
+		})
+		.from(mailboxAliases)
+		.innerJoin(domains, eq(mailboxAliases.domainId, domains.id))
+		.where(eq(mailboxAliases.mailboxId, mailboxId));
+}
+
+export async function GET(request: Request, { params }: MailboxRouteParams) {
+	const { id } = await params;
+	const env = getEnv();
+	const user = await requireUser(env, request);
+	const db = getDb(env);
+	const mailbox = await getManagedMailbox(db, user, id);
+	if (!mailbox) return NextResponse.json({ error: "Mailbox not found" }, { status: 404 });
+
+	const ownerId = await getDomainOwnerId(db, mailbox.domainId);
+	const [aliases, availableDomains] = await Promise.all([
+		listMailboxAliases(db, id),
+		ownerId
+			? db
+					.select({ id: domains.id, hostname: domains.hostname })
+					.from(domains)
+					.where(and(eq(domains.userId, ownerId), eq(domains.status, "active")))
+			: Promise.resolve([]),
+	]);
+
+	return NextResponse.json({ aliases, availableDomains });
+}
+
+export async function POST(request: Request, { params }: MailboxRouteParams) {
+	const { id } = await params;
+	const env = getEnv();
+	const user = await requireUser(env, request);
+	const parsed = createMailboxAliasSchema.safeParse(await request.json());
+	if (!parsed.success) {
+		return NextResponse.json({ error: "Enter a valid alias username and domain" }, { status: 400 });
+	}
+
+	const db = getDb(env);
+	const mailbox = await getManagedMailbox(db, user, id);
+	if (!mailbox) return NextResponse.json({ error: "Mailbox not found" }, { status: 404 });
+
+	const ownerId = await getDomainOwnerId(db, mailbox.domainId);
+	const [domain] = ownerId
+		? await db
+				.select({ id: domains.id, hostname: domains.hostname, zoneId: domains.zoneId })
+				.from(domains)
+				.where(and(
+					eq(domains.id, parsed.data.domainId),
+					eq(domains.userId, ownerId),
+					eq(domains.status, "active"),
+				))
+				.limit(1)
+		: [];
+	if (!domain) return NextResponse.json({ error: "Domain not found" }, { status: 404 });
+
+	const { localPart } = parsed.data;
+	const [existingMailbox] = await db
+		.select({ id: mailboxes.id })
+		.from(mailboxes)
+		.where(and(eq(mailboxes.domainId, domain.id), eq(mailboxes.localPart, localPart)))
+		.limit(1);
+	if (existingMailbox) {
+		return NextResponse.json({ error: "A mailbox already uses this address" }, { status: 409 });
+	}
+	const [existingAlias] = await db
+		.select({ id: mailboxAliases.id })
+		.from(mailboxAliases)
+		.where(and(eq(mailboxAliases.domainId, domain.id), eq(mailboxAliases.localPart, localPart)))
+		.limit(1);
+	if (existingAlias) {
+		return NextResponse.json({ error: "An alias already uses this address" }, { status: 409 });
+	}
+
+	const aliasId = newId("als");
+	await db.insert(mailboxAliases).values({
+		id: aliasId,
+		mailboxId: id,
+		domainId: domain.id,
+		localPart,
+	});
+
+	try {
+		await ensureEmailRoutingRuleToWorker(env, domain.zoneId, `${localPart}@${domain.hostname}`);
+	} catch (error) {
+		console.error("ensureEmailRoutingRuleToWorker", error);
+		await db.delete(mailboxAliases).where(eq(mailboxAliases.id, aliasId));
+		return NextResponse.json(
+			{ error: "Failed to create the Cloudflare Email Routing rule for this alias. Please try again." },
+			{ status: 502 },
+		);
+	}
+
+	const aliases = await listMailboxAliases(db, id);
+	return NextResponse.json({ aliases });
+}
+
+export async function DELETE(request: Request, { params }: MailboxRouteParams) {
+	const { id } = await params;
+	const env = getEnv();
+	const user = await requireUser(env, request);
+	const aliasId = new URL(request.url).searchParams.get("aliasId");
+	if (!aliasId) return NextResponse.json({ error: "Alias is required" }, { status: 400 });
+
+	const db = getDb(env);
+	const mailbox = await getManagedMailbox(db, user, id);
+	if (!mailbox) return NextResponse.json({ error: "Mailbox not found" }, { status: 404 });
+
+	const [alias] = await db
+		.select({
+			id: mailboxAliases.id,
+			domainId: mailboxAliases.domainId,
+			localPart: mailboxAliases.localPart,
+			hostname: domains.hostname,
+			zoneId: domains.zoneId,
+		})
+		.from(mailboxAliases)
+		.innerJoin(domains, eq(mailboxAliases.domainId, domains.id))
+		.where(and(eq(mailboxAliases.id, aliasId), eq(mailboxAliases.mailboxId, id)))
+		.limit(1);
+	if (!alias) return NextResponse.json({ error: "Alias not found" }, { status: 404 });
+
+	// Keep the Cloudflare rule when the address still resolves through a
+	// use-all-domains mailbox or another mailbox's alias on the same address.
+	const [domainAliasMailbox] = await db
+		.select({ id: mailboxes.id })
+		.from(mailboxes)
+		.where(and(
+			eq(mailboxes.localPart, alias.localPart),
+			eq(mailboxes.useAllDomains, true),
+			eq(mailboxes.disabled, false),
+			ne(mailboxes.id, id),
+		))
+		.limit(1);
+
+	if (!domainAliasMailbox) {
+		try {
+			await deleteEmailRoutingRuleForAddress(env, alias.zoneId, `${alias.localPart}@${alias.hostname}`);
+		} catch (error) {
+			console.error("deleteEmailRoutingRuleForAddress", error);
+			return NextResponse.json(
+				{ error: "Failed to remove the Cloudflare Email Routing rule for this alias. Please try again." },
+				{ status: 502 },
+			);
+		}
+	}
+
+	await db.delete(mailboxAliases).where(eq(mailboxAliases.id, aliasId));
+	const aliases = await listMailboxAliases(db, id);
+	return NextResponse.json({ aliases });
+}

--- a/src/app/api/mailboxes/[id]/aliases/route.ts
+++ b/src/app/api/mailboxes/[id]/aliases/route.ts
@@ -116,12 +116,19 @@ export async function POST(request: Request, { params }: MailboxRouteParams) {
 	}
 
 	const aliasId = newId("als");
-	await db.insert(mailboxAliases).values({
-		id: aliasId,
-		mailboxId: id,
-		domainId: domain.id,
-		localPart,
-	});
+	const inserted = await db
+		.insert(mailboxAliases)
+		.values({
+			id: aliasId,
+			mailboxId: id,
+			domainId: domain.id,
+			localPart,
+		})
+		.onConflictDoNothing()
+		.returning({ id: mailboxAliases.id });
+	if (inserted.length === 0) {
+		return NextResponse.json({ error: "An alias already uses this address" }, { status: 409 });
+	}
 
 	try {
 		await ensureEmailRoutingRuleToWorker(env, domain.zoneId, `${localPart}@${domain.hostname}`);

--- a/src/app/api/mailboxes/route.ts
+++ b/src/app/api/mailboxes/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { and, eq } from "drizzle-orm";
 import { getEnv } from "@/lib/cloudflare";
 import { getDb } from "@/db";
-import { domains, mailboxes, users } from "@/db/schema";
+import { domains, mailboxAliases, mailboxes, users } from "@/db/schema";
 import { requireUser } from "@/lib/auth/cookies";
 import { newId } from "@/lib/ids";
 import { getLicenseEntitlements } from "@/lib/licenses/service";
@@ -74,6 +74,14 @@ export async function POST(request: Request) {
 		.limit(1);
 	if (existing) {
 		return NextResponse.json({ error: "Mailbox already exists" }, { status: 409 });
+	}
+	const [existingAlias] = await db
+		.select({ id: mailboxAliases.id })
+		.from(mailboxAliases)
+		.where(and(eq(mailboxAliases.domainId, domain.id), eq(mailboxAliases.localPart, localPart)))
+		.limit(1);
+	if (existingAlias) {
+		return NextResponse.json({ error: "An alias already uses this address" }, { status: 409 });
 	}
 
 	const id = newId("mbx");

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -71,6 +71,27 @@ export const mailboxes = sqliteTable(
 	(t) => [uniqueIndex("mailboxes_address_idx").on(t.domainId, t.localPart)],
 );
 
+export const mailboxAliases = sqliteTable(
+	"mailbox_aliases",
+	{
+		id: text("id").primaryKey(),
+		mailboxId: text("mailbox_id")
+			.notNull()
+			.references(() => mailboxes.id, { onDelete: "cascade" }),
+		domainId: text("domain_id")
+			.notNull()
+			.references(() => domains.id, { onDelete: "cascade" }),
+		localPart: text("local_part").notNull(),
+		createdAt: integer("created_at", { mode: "timestamp" })
+			.notNull()
+			.$defaultFn(() => new Date()),
+	},
+	(t) => [
+		uniqueIndex("mailbox_aliases_address_idx").on(t.domainId, t.localPart),
+		index("mailbox_aliases_mailbox_idx").on(t.mailboxId),
+	],
+);
+
 export const autoReplyDeliveries = sqliteTable(
 	"auto_reply_deliveries",
 	{
@@ -432,6 +453,7 @@ export const schema = {
 	users,
 	domains,
 	mailboxes,
+	mailboxAliases,
 	autoReplyDeliveries,
 	mailboxAccess,
 	contacts,

--- a/src/lib/email/inbound.ts
+++ b/src/lib/email/inbound.ts
@@ -6,7 +6,7 @@ import { buildSnippet, parseRawMime } from "@/lib/email/parse";
 import { resolveInboundAddress, resolveInboxRuleDestination } from "@/lib/email/routing";
 import { dispatchWebhooks } from "@/lib/email/webhooks";
 import { getMessageContactNames, upsertContactFromAddress } from "@/lib/contacts/service";
-import { formatEmailAddress, getEmailAddress } from "@/lib/email/address";
+import { getEmailAddress } from "@/lib/email/address";
 import { sendMailboxAutoReply } from "@/lib/email/auto-reply";
 import { getMailboxAccessLevel } from "@/lib/mailboxes/access";
 import { listMessageAttachments, storeMessageAttachments } from "@/lib/email/attachments";
@@ -59,7 +59,7 @@ export async function processInboundMessage(
 	const messageId = newId("msg");
 	const snippet = buildSnippet(parsed.text, parsed.html);
 	const deliveredAddress = getEmailAddress(payload.to) || `${decision.mailbox.localPart}@${decision.mailbox.hostname}`;
-	const toAddr = formatEmailAddress(deliveredAddress, decision.mailbox.displayName ?? decision.mailbox.localPart);
+	const toAddr = payload.to;
 	const fromAddr = parsed.fromAddr ?? payload.from;
 	const destination = await resolveInboxRuleDestination(db, {
 		mailboxId: decision.mailbox.mailboxId,

--- a/src/lib/email/recipient-address-types.d.ts
+++ b/src/lib/email/recipient-address-types.d.ts
@@ -1,0 +1,6 @@
+export type ParsedRecipientAddress = {
+	original: string;
+	localPart: string;
+	domain: string;
+	normalizedAddress: string;
+};

--- a/src/lib/email/recipient-address.ts
+++ b/src/lib/email/recipient-address.ts
@@ -1,0 +1,24 @@
+import { parseAddress } from "@/lib/utils";
+import type { ParsedRecipientAddress } from "./recipient-address-types";
+
+export function normalizeRecipientLocalPart(localPart: string): string {
+	const [baseLocalPart] = localPart.split("+", 1);
+	return baseLocalPart
+		.replaceAll(".", "")
+		.toLowerCase();
+}
+
+export function parseRecipientAddress(address: string): ParsedRecipientAddress | null {
+	const parsed = parseAddress(address);
+	if (!parsed) return null;
+
+	const localPart = normalizeRecipientLocalPart(parsed.local);
+	if (!localPart) return null;
+
+	return {
+		original: address,
+		localPart,
+		domain: parsed.domain,
+		normalizedAddress: `${localPart}@${parsed.domain}`,
+	};
+}

--- a/src/lib/email/routing.ts
+++ b/src/lib/email/routing.ts
@@ -1,6 +1,6 @@
 import { eq, and, desc } from "drizzle-orm";
 import type { AppDatabase } from "@/db";
-import { domains, folders, mailboxes, routingRules } from "@/db/schema";
+import { domains, folders, mailboxAliases, mailboxes, routingRules } from "@/db/schema";
 import { getEmailAddress } from "@/lib/email/address";
 import { getMailboxDomainAddresses } from "@/lib/mailboxes/domain-addresses";
 import { parseAddress } from "@/lib/utils";
@@ -50,7 +50,9 @@ export async function resolveInboundAddress(
 			eq(mailboxes.disabled, false),
 		))
 		.limit(1);
-	const mailbox = exactMailbox ?? await resolveMailboxDomainAlias(db, domain.hostname, parsed.local);
+	const mailbox = exactMailbox
+		?? await resolveMailboxAlias(db, domain.id, parsed.local)
+		?? await resolveMailboxDomainAlias(db, domain.hostname, parsed.local);
 
 	if (!mailbox) return null;
 
@@ -66,6 +68,20 @@ export async function resolveInboundAddress(
 			displayName: mailbox.displayName,
 		},
 	};
+}
+
+async function resolveMailboxAlias(db: AppDatabase, domainId: string, localPart: string) {
+	const [row] = await db
+		.select({ mailbox: mailboxes })
+		.from(mailboxAliases)
+		.innerJoin(mailboxes, eq(mailboxAliases.mailboxId, mailboxes.id))
+		.where(and(
+			eq(mailboxAliases.domainId, domainId),
+			eq(mailboxAliases.localPart, localPart),
+			eq(mailboxes.disabled, false),
+		))
+		.limit(1);
+	return row?.mailbox ?? null;
 }
 
 async function resolveMailboxDomainAlias(db: AppDatabase, hostname: string, localPart: string) {

--- a/src/lib/email/routing.ts
+++ b/src/lib/email/routing.ts
@@ -3,7 +3,7 @@ import type { AppDatabase } from "@/db";
 import { domains, folders, mailboxAliases, mailboxes, routingRules } from "@/db/schema";
 import { getEmailAddress } from "@/lib/email/address";
 import { getMailboxDomainAddresses } from "@/lib/mailboxes/domain-addresses";
-import { parseAddress } from "@/lib/utils";
+import { normalizeRecipientLocalPart, parseRecipientAddress } from "@/lib/email/recipient-address";
 
 export type ResolvedMailbox = {
 	mailboxId: string;
@@ -30,7 +30,7 @@ export async function resolveInboundAddress(
 	db: AppDatabase,
 	toAddress: string,
 ): Promise<RoutingDecision | null> {
-	const parsed = parseAddress(toAddress);
+	const parsed = parseRecipientAddress(toAddress);
 	if (!parsed) return null;
 
 	const [domain] = await db
@@ -41,18 +41,19 @@ export async function resolveInboundAddress(
 
 	if (!domain) return null;
 
-	const [exactMailbox] = await db
+	const exactMailboxes = await db
 		.select()
 		.from(mailboxes)
 		.where(and(
 			eq(mailboxes.domainId, domain.id),
-			eq(mailboxes.localPart, parsed.local),
 			eq(mailboxes.disabled, false),
-		))
-		.limit(1);
+		));
+	const exactMailbox = exactMailboxes.find(
+		(mailbox) => normalizeRecipientLocalPart(mailbox.localPart) === parsed.localPart,
+	);
 	const mailbox = exactMailbox
-		?? await resolveMailboxAlias(db, domain.id, parsed.local)
-		?? await resolveMailboxDomainAlias(db, domain.hostname, parsed.local);
+		?? await resolveMailboxAlias(db, domain.id, parsed.localPart)
+		?? await resolveMailboxDomainAlias(db, parsed.localPart, parsed.normalizedAddress);
 
 	if (!mailbox) return null;
 
@@ -71,28 +72,38 @@ export async function resolveInboundAddress(
 }
 
 async function resolveMailboxAlias(db: AppDatabase, domainId: string, localPart: string) {
-	const [row] = await db
-		.select({ mailbox: mailboxes })
+	const rows = await db
+		.select({ mailbox: mailboxes, aliasLocalPart: mailboxAliases.localPart })
 		.from(mailboxAliases)
 		.innerJoin(mailboxes, eq(mailboxAliases.mailboxId, mailboxes.id))
 		.where(and(
 			eq(mailboxAliases.domainId, domainId),
-			eq(mailboxAliases.localPart, localPart),
 			eq(mailboxes.disabled, false),
-		))
-		.limit(1);
+		));
+	const row = rows.find(
+		(item) => normalizeRecipientLocalPart(item.aliasLocalPart) === localPart,
+	);
 	return row?.mailbox ?? null;
 }
 
-async function resolveMailboxDomainAlias(db: AppDatabase, hostname: string, localPart: string) {
+async function resolveMailboxDomainAlias(
+	db: AppDatabase,
+	localPart: string,
+	normalizedAddress: string,
+) {
 	const candidates = await db
 		.select()
 		.from(mailboxes)
-		.where(and(eq(mailboxes.localPart, localPart), eq(mailboxes.useAllDomains, true), eq(mailboxes.disabled, false)));
+		.where(and(eq(mailboxes.useAllDomains, true), eq(mailboxes.disabled, false)));
 
 	for (const mailbox of candidates) {
+		if (normalizeRecipientLocalPart(mailbox.localPart) !== localPart) {
+			continue;
+		}
 		const addresses = await getMailboxDomainAddresses(db, mailbox);
-		if (addresses.includes(`${localPart}@${hostname}`.toLowerCase())) {
+		if (addresses.some(
+			(address) => parseRecipientAddress(address)?.normalizedAddress === normalizedAddress,
+		)) {
 			return mailbox;
 		}
 	}

--- a/src/lib/mailboxes/domain-addresses.ts
+++ b/src/lib/mailboxes/domain-addresses.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import type { AppDatabase } from "@/db";
 import { domains, mailboxAliases, mailboxes } from "@/db/schema";
 import { deleteEmailRoutingRuleForAddress, ensureEmailRoutingRuleToWorker } from "@/lib/cloudflare-api";
+import { normalizeRecipientLocalPart } from "@/lib/email/recipient-address";
 import type { MailboxDomainAddressInput } from "./domain-addresses-types";
 
 export async function getMailboxAliasAddresses(
@@ -38,11 +39,25 @@ export async function getMailboxDomainAddresses(
 		.from(domains)
 		.where(and(eq(domains.userId, primaryDomain.userId), eq(domains.status, "active")));
 	const assignedMailboxes = await db
-		.select({ id: mailboxes.id, domainId: mailboxes.domainId })
-		.from(mailboxes)
-		.where(eq(mailboxes.localPart, mailbox.localPart));
+		.select({ id: mailboxes.id, domainId: mailboxes.domainId, localPart: mailboxes.localPart })
+		.from(mailboxes);
+	const assignedAliases = await db
+		.select({
+			mailboxId: mailboxAliases.mailboxId,
+			domainId: mailboxAliases.domainId,
+			localPart: mailboxAliases.localPart,
+		})
+		.from(mailboxAliases);
+	const normalizedLocalPart = normalizeRecipientLocalPart(mailbox.localPart);
 	const assignedDomainIds = new Set(
-		assignedMailboxes.filter((item) => item.id !== mailbox.id).map((item) => item.domainId),
+		[
+			...assignedMailboxes.filter(
+				(item) => item.id !== mailbox.id && normalizeRecipientLocalPart(item.localPart) === normalizedLocalPart,
+			),
+			...assignedAliases.filter(
+				(item) => item.mailboxId !== mailbox.id && normalizeRecipientLocalPart(item.localPart) === normalizedLocalPart,
+			),
+		].map((item) => item.domainId),
 	);
 
 	return [

--- a/src/lib/mailboxes/domain-addresses.ts
+++ b/src/lib/mailboxes/domain-addresses.ts
@@ -1,8 +1,20 @@
 import { and, eq } from "drizzle-orm";
 import type { AppDatabase } from "@/db";
-import { domains, mailboxes } from "@/db/schema";
+import { domains, mailboxAliases, mailboxes } from "@/db/schema";
 import { deleteEmailRoutingRuleForAddress, ensureEmailRoutingRuleToWorker } from "@/lib/cloudflare-api";
 import type { MailboxDomainAddressInput } from "./domain-addresses-types";
+
+export async function getMailboxAliasAddresses(
+	db: AppDatabase,
+	mailboxId: string,
+): Promise<string[]> {
+	const aliases = await db
+		.select({ localPart: mailboxAliases.localPart, hostname: domains.hostname })
+		.from(mailboxAliases)
+		.innerJoin(domains, eq(mailboxAliases.domainId, domains.id))
+		.where(eq(mailboxAliases.mailboxId, mailboxId));
+	return aliases.map((alias) => `${alias.localPart}@${alias.hostname}`.toLowerCase());
+}
 
 export async function getMailboxDomainAddresses(
 	db: AppDatabase,
@@ -16,7 +28,10 @@ export async function getMailboxDomainAddresses(
 	if (!primaryDomain) return [];
 
 	const primaryAddress = `${mailbox.localPart}@${primaryDomain.hostname}`.toLowerCase();
-	if (!mailbox.useAllDomains) return [primaryAddress];
+	const aliasAddresses = await getMailboxAliasAddresses(db, mailbox.id);
+	if (!mailbox.useAllDomains) {
+		return [...new Set([primaryAddress, ...aliasAddresses])];
+	}
 
 	const availableDomains = await db
 		.select({ id: domains.id, hostname: domains.hostname })
@@ -31,10 +46,13 @@ export async function getMailboxDomainAddresses(
 	);
 
 	return [
-		primaryAddress,
-		...availableDomains
-			.filter((domain) => domain.id !== mailbox.domainId && !assignedDomainIds.has(domain.id))
-			.map((domain) => `${mailbox.localPart}@${domain.hostname}`.toLowerCase()),
+		...new Set([
+			primaryAddress,
+			...availableDomains
+				.filter((domain) => domain.id !== mailbox.domainId && !assignedDomainIds.has(domain.id))
+				.map((domain) => `${mailbox.localPart}@${domain.hostname}`.toLowerCase()),
+			...aliasAddresses,
+		]),
 	];
 }
 

--- a/src/lib/setup/migration.ts
+++ b/src/lib/setup/migration.ts
@@ -22,6 +22,7 @@ const MIGRATION_NAMES = [
 	"0020_add_calendar_templates_schedule.sql",
 	"0021_add_mailbox_signature.sql",
 	"0022_add_mailbox_auto_reply.sql",
+	"0023_add_mailbox_aliases.sql",
 ];
 
 const INITIAL_SCHEMA_SQL = `
@@ -32,6 +33,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS domains_hostname_idx ON domains(hostname);
 CREATE INDEX IF NOT EXISTS domains_user_idx ON domains(user_id);
 CREATE TABLE IF NOT EXISTS mailboxes (id text PRIMARY KEY NOT NULL, user_id text NOT NULL REFERENCES users(id) ON DELETE cascade, domain_id text NOT NULL REFERENCES domains(id) ON DELETE cascade, local_part text NOT NULL, display_name text, signature text, auto_reply_enabled integer DEFAULT false NOT NULL, auto_reply_subject text DEFAULT 'Out of office' NOT NULL, auto_reply_body text DEFAULT '' NOT NULL, avatar_key text, type text DEFAULT 'personal' NOT NULL, use_all_domains integer DEFAULT true NOT NULL, disabled integer DEFAULT false NOT NULL, created_at integer NOT NULL);
 CREATE UNIQUE INDEX IF NOT EXISTS mailboxes_address_idx ON mailboxes(domain_id, local_part);
+CREATE TABLE IF NOT EXISTS mailbox_aliases (id text PRIMARY KEY NOT NULL, mailbox_id text NOT NULL REFERENCES mailboxes(id) ON DELETE cascade, domain_id text NOT NULL REFERENCES domains(id) ON DELETE cascade, local_part text NOT NULL, created_at integer NOT NULL);
+CREATE UNIQUE INDEX IF NOT EXISTS mailbox_aliases_address_idx ON mailbox_aliases(domain_id, local_part);
+CREATE INDEX IF NOT EXISTS mailbox_aliases_mailbox_idx ON mailbox_aliases(mailbox_id);
 CREATE TABLE IF NOT EXISTS auto_reply_deliveries (id text PRIMARY KEY NOT NULL, mailbox_id text NOT NULL REFERENCES mailboxes(id) ON DELETE cascade, recipient text NOT NULL, sent_at integer NOT NULL);
 CREATE UNIQUE INDEX IF NOT EXISTS auto_reply_deliveries_mailbox_recipient_idx ON auto_reply_deliveries(mailbox_id, recipient);
 CREATE INDEX IF NOT EXISTS auto_reply_deliveries_sent_idx ON auto_reply_deliveries(sent_at);

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -130,6 +130,17 @@ export const updateMailboxSchema = z.object({
 	useAllDomains: z.boolean().optional(),
 });
 
+export const createMailboxAliasSchema = z.object({
+	domainId: z.string().min(1),
+	localPart: z
+		.string()
+		.trim()
+		.min(1)
+		.max(64)
+		.regex(/^[a-zA-Z0-9._%+-]+$/)
+		.transform((value) => value.toLowerCase()),
+});
+
 export const folderSchema = z.object({
 	mailboxId: z.string().min(1),
 	name: z.string().trim().min(1).max(80),


### PR DESCRIPTION
Adds support for arbitrary email aliases: any local part on any active domain can now be attached to a mailbox as an extra delivery address, alongside the existing use-all-domains behavior.

## Changes

- New `mailbox_aliases` table (migration `0023_add_mailbox_aliases.sql` + setup bootstrap schema), unique per domain+local part, cascade-deleted with mailbox or domain
- Inbound routing resolves exact mailbox → explicit alias → use-all-domains fallback
- Alias addresses are included in `getMailboxDomainAddresses`, so the compose "from" picker, send-as permission checks, and Cloudflare rule cleanup on mailbox delete all cover aliases
- New API: `GET/POST /api/mailboxes/[id]/aliases` and `DELETE ...?aliasId=` — gated by mailbox manage access, validates domain ownership + active status, rejects collisions with existing mailboxes/aliases, creates the Cloudflare Email Routing rule (row rolled back if the rule fails)
- Alias delete keeps the Cloudflare rule when a use-all-domains mailbox still claims the address
- Mailbox creation now rejects addresses already taken by an alias
- "Aliases" card on the mailbox settings page to add/remove aliases

Also syncs the stale `package-lock.json` name/version (`mailflare-team@0.1.9`) with `package.json` (`mailflare@0.2.0`).

https://claude.ai/code/session_01F4guPNmWdPyqn4YGccFEtv