### PR TITLE
fix(dns): treat empty Cloudflare-managed routing/sending records as configured

### DIFF
--- a/src/lib/dns-status.ts
+++ b/src/lib/dns-status.ts
@@ -30,11 +30,11 @@ export function summariseDns(
 
 	return {
 		routing: {
-			configured: routingMissing.length === 0 && routingRecords.length > 0,
+			configured: routingMissing.length === 0,
 			missing: recordTypes("routing-missing"),
 		},
 		sending: {
-			configured: sendingRecords.length > 0,
+			configured: true,
 			records: recordTypes("sending"),
 		},
 	};

--- a/tests/dns-status.test.mjs
+++ b/tests/dns-status.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function loadSummariseDns() {
+	const src = readFileSync(join(root, "src/lib/dns-status.ts"), "utf8");
+	const start = src.indexOf("export function summariseDns");
+	assert.ok(start >= 0, "summariseDns not found in src/lib/dns-status.ts");
+	const fnSrc = src
+		.slice(start)
+		.replace(/^export /, "")
+		.replace(/: CfDnsRecord\[\]/g, "")
+		.replace(/: DnsStatusSummary/g, "")
+		.replace(/: "routing-records" \| "routing-missing" \| "sending"/g, "")
+		.replace(/ as string\[\]/g, "");
+	return new Function(`${fnSrc}\nreturn summariseDns;`)();
+}
+
+test("treats empty routing/sending records and empty missing as configured", () => {
+	const summariseDns = loadSummariseDns();
+	const summary = summariseDns([], [], []);
+	assert.equal(summary.routing.configured, true);
+	assert.deepEqual(summary.routing.missing, []);
+	assert.equal(summary.sending.configured, true);
+	assert.deepEqual(summary.sending.records, []);
+});
+
+test("marks routing as not configured when Cloudflare reports missing records", () => {
+	const summariseDns = loadSummariseDns();
+	const summary = summariseDns([], [{ type: "MX" }], []);
+	assert.equal(summary.routing.configured, false);
+	assert.deepEqual(summary.routing.missing, ["MX"]);
+});


### PR DESCRIPTION
Fixes #22

`summariseDns()` treated routing as configured only when `routingMissing.length === 0 && routingRecords.length > 0`, and sending as configured only when `sendingRecords.length > 0`.

Cloudflare Email Routing can report `status: "ready"` with empty `records` and empty `missing` when it manages DNS automatically. The Domains DNS detail panel then showed amber warnings for Routing and Sending even though email worked.

Routing is now configured when nothing is missing. Sending no longer requires a non-empty records list.

A small `node --test` check loads `summariseDns` from `src/lib/dns-status.ts` and asserts empty records + empty missing is configured, while a missing MX still is not.