### PR TITLE
fix(domains): roll back only the Cloudflare config a failed setup created (#20)

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -8,7 +8,9 @@ import { hasAdminAccount } from "@/lib/auth/setup";
 import { createSession, SESSION_COOKIE } from "@/lib/auth/session";
 import { newId } from "@/lib/ids";
 import { firstRunRegisterSchema } from "@/lib/validators";
-import { addDomainForUser, listUserDomains, removeDomainForUser } from "@/lib/domains/service";
+import { addDomainForUser } from "@/lib/domains/service";
+import { rollbackDomainProvisioning } from "@/lib/domains/rollback";
+import type { DomainProvisioningChanges } from "@/lib/domains/types";
 import { ensureEmailRoutingRuleToWorker } from "@/lib/cloudflare-api";
 import { ensureMailboxDomainRouting } from "@/lib/mailboxes/domain-addresses";
 import { readJsonBody } from "@/lib/http/request";
@@ -58,12 +60,21 @@ export async function POST(request: Request) {
 		role: "admin",
 	});
 
+	// Tracks what the attempt changed on the Cloudflare zone so a failure can undo
+	// precisely that. The DB is not a reliable source for this: the same errors that
+	// abort registration (an unmigrated schema, a dead D1 binding) also stop the
+	// domain row from ever being written, which is exactly when the orphaned zone
+	// config would go unnoticed.
+	let changes: DomainProvisioningChanges | null = null;
 	try {
-		const { domain } = await addDomainForUser(env, userId, domainName, {
+		const added = await addDomainForUser(env, userId, domainName, {
 			enableRouting: true,
 			enableSending: true,
 		});
+		const domain = added.domain;
+		changes = added.changes;
 		await ensureEmailRoutingRuleToWorker(env, domain.zoneId, email);
+		changes.createdAddressRules.push(email);
 		const mailboxId = newId("mbx");
 		await db.insert(mailboxes).values({
 			id: mailboxId,
@@ -74,13 +85,13 @@ export async function POST(request: Request) {
 		});
 		await ensureMailboxDomainRouting(env, db, { id: mailboxId, domainId: domain.id, localPart: username, useAllDomains: true });
 	} catch (err) {
+		if (changes) await rollbackDomainProvisioning(env, changes);
 		try {
-			const [domain] = await listUserDomains(env, userId);
-			if (domain) await removeDomainForUser(env, userId, domain.id);
+			// The domain row cascades with the user.
+			await db.delete(users).where(eq(users.id, userId));
 		} catch (cleanupError) {
-			console.warn("Failed to roll back domain after registration failure", cleanupError);
+			console.warn("Failed to remove the partial user after registration failure", cleanupError);
 		}
-		await db.delete(users).where(eq(users.id, userId));
 		const message = err instanceof Error ? err.message : "Domain setup failed";
 		return NextResponse.json({ error: message }, { status: 502 });
 	}

--- a/src/lib/domains/catch-all-routing.ts
+++ b/src/lib/domains/catch-all-routing.ts
@@ -2,6 +2,21 @@ import { cfRequest } from "@/lib/cloudflare-api";
 import type { CfEmailRoutingRule } from "@/lib/cloudflare-api.types";
 import { getEmailWorkerName } from "@/lib/cloudflare-api-utils";
 
+export async function getEmailRoutingCatchAll(
+	env: CloudflareEnv,
+	zoneId: string,
+): Promise<CfEmailRoutingRule | null> {
+	try {
+		return await cfRequest<CfEmailRoutingRule>(
+			env,
+			`/zones/${zoneId}/email/routing/rules/catch_all`,
+		);
+	} catch {
+		// A zone without Email Routing has no catch-all to read; treat it as absent.
+		return null;
+	}
+}
+
 export async function ensureEmailRoutingCatchAllToWorker(
 	env: CloudflareEnv,
 	zoneId: string,
@@ -17,6 +32,34 @@ export async function ensureEmailRoutingCatchAllToWorker(
 				enabled: true,
 				matchers: [{ type: "all" }],
 				name: `Route all email to ${workerName}`,
+			}),
+		},
+	);
+}
+
+/**
+ * Put back a catch-all captured before `ensureEmailRoutingCatchAllToWorker`
+ * overwrote it. The catch-all is a singleton per zone, so it cannot be deleted —
+ * restoring means writing the previous rule back, or falling back to
+ * Cloudflare's own default (a disabled drop) when the zone never had one.
+ */
+export async function restoreEmailRoutingCatchAll(
+	env: CloudflareEnv,
+	zoneId: string,
+	previous: CfEmailRoutingRule | null,
+): Promise<void> {
+	const actions = previous?.actions?.length ? previous.actions : [{ type: "drop" as const }];
+	const matchers = previous?.matchers?.length ? previous.matchers : [{ type: "all" as const }];
+	await cfRequest<CfEmailRoutingRule>(
+		env,
+		`/zones/${zoneId}/email/routing/rules/catch_all`,
+		{
+			method: "PUT",
+			body: JSON.stringify({
+				actions,
+				enabled: previous?.enabled ?? false,
+				matchers,
+				...(previous?.name ? { name: previous.name } : {}),
 			}),
 		},
 	);

--- a/src/lib/domains/provision.ts
+++ b/src/lib/domains/provision.ts
@@ -2,11 +2,15 @@ import {
 	createSendingSubdomain,
 	enableEmailRouting,
 	findZoneByHostname,
+	getEmailRoutingSettings,
 	listSendingSubdomains,
 } from "@/lib/cloudflare-api";
-import { ensureEmailRoutingCatchAllToWorker } from "@/lib/domains/catch-all-routing";
+import {
+	ensureEmailRoutingCatchAllToWorker,
+	getEmailRoutingCatchAll,
+} from "@/lib/domains/catch-all-routing";
 import { isZoneApex } from "@/lib/domains/utils";
-import type { DomainProvisioningResult } from "@/lib/domains/types";
+import type { DomainProvisioningChanges, DomainProvisioningResult } from "@/lib/domains/types";
 
 export async function provisionDomainOnCloudflare(
 	env: CloudflareEnv,
@@ -28,10 +32,32 @@ export async function provisionDomainOnCloudflare(
 	let sendingEnabled = false;
 	let sendingSubdomainTag: string | null = null;
 	let routingStatus: string | undefined;
+	const changes: DomainProvisioningChanges = {
+		zoneId: zone.id,
+		enabledEmailRouting: false,
+		createdSendingSubdomainTag: null,
+		previousCatchAll: null,
+		createdAddressRules: [],
+	};
 
 	if (enableRouting) {
+		// Record the zone's prior state before changing it: rolling back must only
+		// undo what this call did, never Email Routing the account already had.
+		// If the state cannot be read, assume it was already on — leaving an orphan
+		// behind is far cheaper than disabling a zone someone else's mail depends on.
+		let routingWasEnabled = true;
+		try {
+			const settings = await getEmailRoutingSettings(env, zone.id);
+			routingWasEnabled = settings.enabled === true;
+		} catch {
+			// Keep the fail-safe default.
+		}
+		// The catch-all is a singleton and the PUT below overwrites it, so keep a copy.
+		changes.previousCatchAll = routingWasEnabled ? await getEmailRoutingCatchAll(env, zone.id) : null;
+
 		const routingName = isZoneApex(normalized, zone.name) ? undefined : normalized;
 		const routing = await enableEmailRouting(env, zone.id, routingName);
+		changes.enabledEmailRouting = !routingWasEnabled;
 		routingEnabled = routing.enabled ?? true;
 		routingStatus = routing.status;
 		await ensureEmailRoutingCatchAllToWorker(env, zone.id);
@@ -50,6 +76,7 @@ export async function provisionDomainOnCloudflare(
 				const created = await createSendingSubdomain(env, zone.id, normalized);
 				sendingSubdomainTag = created.tag;
 				sendingEnabled = created.enabled;
+				changes.createdSendingSubdomainTag = created.tag;
 			}
 		}
 	}
@@ -61,5 +88,6 @@ export async function provisionDomainOnCloudflare(
 		sendingEnabled,
 		sendingSubdomainTag,
 		routingStatus,
+		changes,
 	};
 }

--- a/src/lib/domains/rollback.ts
+++ b/src/lib/domains/rollback.ts
@@ -1,0 +1,56 @@
+import {
+	deleteEmailRoutingRuleForAddress,
+	deleteSendingSubdomain,
+	disableEmailRouting,
+} from "@/lib/cloudflare-api";
+import { restoreEmailRoutingCatchAll } from "@/lib/domains/catch-all-routing";
+import type { DomainProvisioningChanges } from "@/lib/domains/types";
+
+async function attempt(label: string, run: () => Promise<unknown>): Promise<void> {
+	try {
+		await run();
+	} catch (err) {
+		// A rollback runs while another error is already on its way to the caller,
+		// so a failure here must be logged, never thrown — it would mask the cause.
+		console.warn(`rollbackDomainProvisioning: ${label}`, err);
+	}
+}
+
+/**
+ * Undo exactly what a provisioning attempt changed on the zone, so a failed
+ * signup or domain add leaves the Cloudflare account as it was rather than
+ * stranding Email Routing and a sending subdomain with nothing referencing them.
+ *
+ * Anything the attempt merely reused is deliberately left alone.
+ */
+export async function rollbackDomainProvisioning(
+	env: CloudflareEnv,
+	changes: DomainProvisioningChanges,
+): Promise<void> {
+	const { zoneId } = changes;
+
+	for (const address of changes.createdAddressRules) {
+		await attempt(`deleteEmailRoutingRuleForAddress ${address}`, () =>
+			deleteEmailRoutingRuleForAddress(env, zoneId, address),
+		);
+	}
+
+	if (changes.createdSendingSubdomainTag) {
+		await attempt("deleteSendingSubdomain", () =>
+			deleteSendingSubdomain(env, zoneId, changes.createdSendingSubdomainTag!),
+		);
+	}
+
+	// Restore before disabling: Cloudflare keeps the routing config around when
+	// Email Routing is switched off, so leaving the Worker catch-all in place would
+	// quietly resurrect it the next time someone re-enables routing on the zone.
+	if (changes.previousCatchAll || changes.enabledEmailRouting) {
+		await attempt("restoreEmailRoutingCatchAll", () =>
+			restoreEmailRoutingCatchAll(env, zoneId, changes.previousCatchAll),
+		);
+	}
+
+	if (changes.enabledEmailRouting) {
+		await attempt("disableEmailRouting", () => disableEmailRouting(env, zoneId));
+	}
+}

--- a/src/lib/domains/service.ts
+++ b/src/lib/domains/service.ts
@@ -14,6 +14,8 @@ import {
 } from "@/lib/cloudflare-api";
 import { deleteEmailRoutingRulesForDomain } from "@/lib/domains/cloudflare-cleanup";
 import { provisionDomainOnCloudflare } from "@/lib/domains/provision";
+import { rollbackDomainProvisioning } from "@/lib/domains/rollback";
+import type { DomainProvisioningChanges } from "@/lib/domains/types";
 import { findSendingSubdomain } from "@/lib/domains/sending-status";
 
 export type DomainDnsView = {
@@ -32,49 +34,75 @@ export async function addDomainForUser(
 	userId: string,
 	hostname: string,
 	options?: { enableRouting?: boolean; enableSending?: boolean },
-): Promise<{ domain: typeof domains.$inferSelect; dns: DomainDnsView }> {
+): Promise<{
+	domain: typeof domains.$inferSelect;
+	dns: DomainDnsView;
+	changes: DomainProvisioningChanges;
+}> {
 	const provisioned = await provisionDomainOnCloudflare(env, hostname, options);
-
 	const db = getDb(env);
-	const [existing] = await db.select().from(domains).where(eq(domains.hostname, provisioned.hostname)).limit(1);
-	if (existing && existing.userId !== userId) {
-		throw new Error("Domain is already registered");
+	let insertedDomainId: string | null = null;
+	let domain: typeof domains.$inferSelect;
+
+	try {
+		const [existing] = await db.select().from(domains).where(eq(domains.hostname, provisioned.hostname)).limit(1);
+		if (existing && existing.userId !== userId) {
+			throw new Error("Domain is already registered");
+		}
+
+		const domainId = existing?.id ?? newId("dom");
+		const values = {
+			id: domainId,
+			userId,
+			hostname: provisioned.hostname,
+			zoneId: provisioned.zone.id,
+			status: provisioned.routingEnabled || provisioned.sendingEnabled ? ("active" as const) : ("pending" as const),
+			routingStatus: provisioned.routingStatus ?? null,
+			sendingSubdomainTag: provisioned.sendingSubdomainTag,
+			sendingEnabled: provisioned.sendingEnabled,
+			routingEnabled: provisioned.routingEnabled,
+		};
+
+		if (existing) {
+			await db.update(domains).set(values).where(eq(domains.id, domainId));
+		} else {
+			await db.insert(domains).values(values);
+			insertedDomainId = domainId;
+		}
+
+		const aliasMailboxes = await db
+			.select({ id: mailboxes.id, domainId: mailboxes.domainId, localPart: mailboxes.localPart, useAllDomains: mailboxes.useAllDomains })
+			.from(mailboxes)
+			.innerJoin(domains, eq(mailboxes.domainId, domains.id))
+			.where(and(eq(domains.userId, userId), eq(mailboxes.useAllDomains, true)));
+		const routingResults = await Promise.allSettled(
+			aliasMailboxes.map((mailbox) => ensureMailboxDomainRouting(env, db, mailbox)),
+		);
+		for (const result of routingResults) {
+			if (result.status === "rejected") console.warn("ensureMailboxDomainRouting", result.reason);
+		}
+
+		const [row] = await db.select().from(domains).where(eq(domains.id, domainId)).limit(1);
+		domain = row!;
+	} catch (err) {
+		// The zone was already provisioned above. Anything that fails after that —
+		// a hostname owned by another user, an unmigrated D1 schema — would otherwise
+		// strand Email Routing and the sending subdomain with nothing referencing them.
+		await rollbackDomainProvisioning(env, provisioned.changes);
+		if (insertedDomainId) {
+			try {
+				await db.delete(domains).where(eq(domains.id, insertedDomainId));
+			} catch (cleanupError) {
+				console.warn("addDomainForUser: failed to remove partial domain row", cleanupError);
+			}
+		}
+		throw err;
 	}
 
-	const domainId = existing?.id ?? newId("dom");
-	const values = {
-		id: domainId,
-		userId,
-		hostname: provisioned.hostname,
-		zoneId: provisioned.zone.id,
-		status: provisioned.routingEnabled || provisioned.sendingEnabled ? ("active" as const) : ("pending" as const),
-		routingStatus: provisioned.routingStatus ?? null,
-		sendingSubdomainTag: provisioned.sendingSubdomainTag,
-		sendingEnabled: provisioned.sendingEnabled,
-		routingEnabled: provisioned.routingEnabled,
-	};
-
-	if (existing) {
-		await db.update(domains).set(values).where(eq(domains.id, domainId));
-	} else {
-		await db.insert(domains).values(values);
-	}
-
-	const aliasMailboxes = await db
-		.select({ id: mailboxes.id, domainId: mailboxes.domainId, localPart: mailboxes.localPart, useAllDomains: mailboxes.useAllDomains })
-		.from(mailboxes)
-		.innerJoin(domains, eq(mailboxes.domainId, domains.id))
-		.where(and(eq(domains.userId, userId), eq(mailboxes.useAllDomains, true)));
-	const routingResults = await Promise.allSettled(
-		aliasMailboxes.map((mailbox) => ensureMailboxDomainRouting(env, db, mailbox)),
-	);
-	for (const result of routingResults) {
-		if (result.status === "rejected") console.warn("ensureMailboxDomainRouting", result.reason);
-	}
-
-	const [domain] = await db.select().from(domains).where(eq(domains.id, domainId)).limit(1);
-	const dns = await getDomainDns(env, domain!);
-	return { domain: domain!, dns };
+	// Read the DNS view outside the rollback scope: the domain is fully set up by
+	// now, so a failed status read must not tear it back down.
+	const dns = await getDomainDns(env, domain);
+	return { domain, dns, changes: provisioned.changes };
 }
 
 export async function getDomainDns(

--- a/src/lib/domains/types.d.ts
+++ b/src/lib/domains/types.d.ts
@@ -1,4 +1,24 @@
 import type { domains } from "@/db/schema";
+import type { CfEmailRoutingRule } from "@/lib/cloudflare-api.types";
+
+/**
+ * Exactly what one provisioning attempt changed on the Cloudflare zone, so a
+ * failure further along can undo its own work and nothing else. Provisioning is
+ * idempotent — it happily reuses Email Routing or a sending subdomain the zone
+ * already had — and tearing those down would leave the account worse off than
+ * the orphaned config the rollback exists to prevent.
+ */
+export type DomainProvisioningChanges = {
+	zoneId: string;
+	/** Email Routing was off before this attempt and this attempt turned it on. */
+	enabledEmailRouting: boolean;
+	/** Tag of a sending subdomain this attempt created; null when one already existed. */
+	createdSendingSubdomainTag: string | null;
+	/** The zone's catch-all rule as it stood before this attempt overwrote it. */
+	previousCatchAll: CfEmailRoutingRule | null;
+	/** Addresses this attempt pointed at the Worker, filled in as they are created. */
+	createdAddressRules: string[];
+};
 
 export type DomainProvisioningResult = {
 	hostname: string;
@@ -7,6 +27,7 @@ export type DomainProvisioningResult = {
 	sendingEnabled: boolean;
 	sendingSubdomainTag: string | null;
 	routingStatus?: string;
+	changes: DomainProvisioningChanges;
 };
 
 export type DomainRow = typeof domains.$inferSelect;


### PR DESCRIPTION
Follows up on #20. `e5f45f5` already added a rollback for the orphaned Cloudflare config that issue reports — this makes it fire in the case the issue actually reproduces, and stops it from removing config the zone already had.

## What

`e5f45f5` rolls back via `listUserDomains` → `removeDomainForUser`, i.e. it drives the Cloudflare teardown from the database. Two problems come from that:

**1. It can't fire in the case #20 reproduces.** The failures that abort registration — the unmigrated schema the issue names, a dead D1 binding — are the same ones that stop the `domains` row from ever being written. `listUserDomains` comes back empty, `removeDomainForUser` is never reached, and the zone keeps the orphan.

**2. It can leave the account worse off than the orphan.** `provisionDomainOnCloudflare` is idempotent: it happily reuses Email Routing, a sending subdomain, and the catch-all a zone already has. But `removeDomainForUser` tears all of that down unconditionally, and `ensureEmailRoutingCatchAllToWorker` PUTs over the zone's existing catch-all with nothing saved to put back. A signup that fails against a zone already forwarding mail would disable Email Routing on it and delete the user's own routing rules.

## Why

The goal in #20 is "leave the Cloudflare zone in the state it was in before the attempt." That needs two things the DB can't provide: it has to work when the database is the thing that failed, and it has to distinguish what the attempt *created* from what it merely *reused*.

So provisioning now reports exactly what it changed, and the rollback undoes precisely that — nothing more.

## Where

| File | Change |
| --- | --- |
| `src/lib/domains/types.d.ts` | New `DomainProvisioningChanges`: did this attempt enable Email Routing, did it create the sending subdomain, what was the catch-all before it was overwritten, which address rules it added. |
| `src/lib/domains/provision.ts` | Reads the zone's prior state before touching it and fills in `changes`. If that read fails it assumes routing was **already on**, so a zone whose state can't be determined is never disabled. |
| `src/lib/domains/catch-all-routing.ts` | Adds `getEmailRoutingCatchAll` and `restoreEmailRoutingCatchAll`. The catch-all is a per-zone singleton and can't be deleted, so restoring means writing the previous rule back — or Cloudflare's own default (a disabled drop) when the zone never had one. |
| `src/lib/domains/rollback.ts` *(new)* | `rollbackDomainProvisioning` — address rules, then the created subdomain, then restore the catch-all, then disable routing. Every step is best-effort and logs rather than throws: a rollback runs while another error is already on its way to the caller and must not mask it. |
| `src/lib/domains/service.ts` | `addDomainForUser` rolls back its own provisioning before rethrowing, which closes gap 1 for `POST /api/domains` too, and drops a partial `domains` row if it wrote one. The DNS status read moved outside that scope — the domain is fully set up by then, so a failed status read must not tear it back down. |
| `src/app/api/auth/register/route.ts` | Rolls back from the captured `changes` instead of `listUserDomains` + `removeDomainForUser`. Also guards the `users` delete, so a dead D1 binding still returns the 502 with the real cause instead of a 500. |

The catch-all is restored *before* routing is disabled, on the assumption that Cloudflare keeps routing config across a disable/re-enable. If it doesn't, the extra PUT is harmless; if it does, it stops the Worker catch-all quietly resurfacing later.

`removeDomainForUser` is deliberately left as-is — deleting a domain is an explicit user action with a different contract from undoing a failed setup.

## Verification

There's no test runner in the repo, so I drove the real provision/rollback code against an in-memory fake of the Email Routing API. 18 checks, all passing:

- **Fresh zone** — rollback restores it byte for byte (routing off, subdomain gone, catch-all back to the default drop).
- **Zone already using Email Routing** — provisioning correctly declines to claim credit for the routing and subdomain it reused; after rollback the zone keeps its routing enabled, its forwarding catch-all restored and re-enabled, its pre-existing subdomain, and its own routing rule. Only the address rule this attempt created is removed.
- **#20's own repro** — provisioning succeeds, then every query throws `no such table: domains`. The zone is still rolled back and the original error still reaches the caller.

No behaviour change on success.

`npx tsc --noEmit` and `npm run lint` are unchanged from the baseline on `main` (12 type errors, 96 lint problems — all pre-existing). `npm run build` compiles; it stops later at static generation on the `send_email` `"remote": true` binding wanting `CLOUDFLARE_API_TOKEN`, which is a local-environment thing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGeWDVSkXtVEmDAN2AtB9h
